### PR TITLE
Added experimental detection support for EFM boards for Windows

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -67,9 +67,22 @@ class MbedLsToolsBase:
 
         "9009": "ARCH_BLE",
 
+        # EFMs
+        "20__": "EFM32_G8XX_STK",   # Not supported detection
+        "2030": "EFM32ZG_STK3200",
+        "20__": "EFM32TG_STK3300",  # Not supported detection
+        "20__": "EFM32HG_STK3400",  # Not supported detection
+        "2020": "EFM32LG_STK3600",
+        "2015": "EFM32GG_STK3700",
+        "2010": "EFM32WG_STK3800",
+
         #Other boards, not officialy supported yet
         "5020": "HOME_GATEWAY_6LOWPAN"
     }
+
+    #
+    # Note: 'Ven_SEGGER' - This is used to detect devices from EFM family, they use Segger J-LInk to wrap MSD and CDC
+    usb_vendor_list = ['Ven_MBED', 'Ven_SEGGER']
 
     # Interface
     def list_mbeds(self):

--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -147,8 +147,13 @@ class MbedLsToolsWin7(MbedLsToolsBase):
 
     def get_mbed_devices(self):
         """ Get MBED devices (connected or not)
+            Note: We will detect also non-standard MBED devices mentioned on 'usb_vendor_list' list.
+                  This will help to detect boards like EFM boards.
         """
-        return [d for d in self.get_dos_devices() if 'VEN_MBED' in d[1].upper()]
+        result = []
+        for ven in self.usb_vendor_list:
+            result += [d for d in self.get_dos_devices() if ven.upper() in d[1].upper()]
+        return result
 
     def get_dos_devices(self):
         """ Get DOS devices (connected or not)


### PR DESCRIPTION
# Description

Added support for EFM board family for Windows 7.
No support and not tested for:
- Ubuntu,
- MacOS.

Note: This implementation detects below boards only:
- EFM32ZG_STK3200,
- EFM32LG_STK3600,
- EFM32GG_STK3700,
- EFM32WG_STK3800.
# Testing

Tested command line detection for Windows 7, not tested with test suite or mbed-greentea.

```
$ mbedls
+-----------------------+-------------------+-------------------+--------------------------------+
|platform_name          |mount_point        |serial_port        |target_id                       |
+-----------------------+-------------------+-------------------+--------------------------------+
|EFM32LG_STK3600        |E:                 |COM108             |20200009000056BFD6506545        |
|EFM32WG_STK3800        |F:                 |COM107             |2010000900005541D650668B        |
+-----------------------+-------------------+-------------------+--------------------------------+
```
