### PR TITLE
Fixed runtime issue on mac

### DIFF
--- a/mbed_lstools/lstools_darwin.py
+++ b/mbed_lstools/lstools_darwin.py
@@ -63,9 +63,9 @@ class MbedLsToolsDarwin(MbedLsToolsBase):
             if result[i]['mount_point']:
                 # Deducing mbed-enabled TargetID based on available targetID definition DB.
                 # If TargetID from USBID is not recognized we will try to check URL in mbed.htm
-                htm_target_id = self.get_mbed_htm_target_id(m['mount_point'])
+                htm_target_id = self.get_mbed_htm_target_id(result[i]['mount_point'])
                 if htm_target_id:
-                    result[i]['target_id_usb_id'] = m['target_id']
+                    result[i]['target_id_usb_id'] = result[i]['target_id']
                     result[i]['target_id'] = htm_target_id
                     result[i]['platform_name'] = self.platform_name(htm_target_id[:4])
                 result[i]['target_id_mbed_htm'] = htm_target_id
@@ -165,5 +165,3 @@ class MbedLsToolsDarwin(MbedLsToolsBase):
     def platform_name(self, target_id):
         if target_id[:4] in self.manufacture_ids:
             return self.manufacture_ids[target_id[:4]]
-
-


### PR DESCRIPTION
Fixes the following error on Mac when running mbed-ls with mbeds connected:

```
$ mbedls
Traceback (most recent call last):
  File "/usr/local/bin/mbedls", line 9, in <module>
    load_entry_point('mbed-ls==0.1.12', 'console_scripts', 'mbedls')()
  File "build/bdist.macosx-10.9-x86_64/egg/mbed_lstools/main.py", line 97, in mbedls_main
  File "build/bdist.macosx-10.9-x86_64/egg/mbed_lstools/lstools_base.py", line 228, in get_string
  File "build/bdist.macosx-10.9-x86_64/egg/mbed_lstools/lstools_base.py", line 185, in list_mbeds_ext
  File "build/bdist.macosx-10.9-x86_64/egg/mbed_lstools/lstools_darwin.py", line 66, in list_mbeds
NameError: global name 'm' is not defined
```
