### PR TITLE
Add new switch --mock used to map not existing platforms (devel prototyping support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 
+# mbed-ls related files
+.mbedls-mock
+
 # C extensions
 *.so
 

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -169,12 +169,16 @@ class MbedLsToolsBase:
         @return Curent mocking configuration (dictionary)
         """
         if os.path.isfile(self.MOCK_FILE_NAME):
+            if self.DEBUG_FLAG:
+                self.debug(self.mock_read.__name__, "reading %s"% self.MOCK_FILE_NAME)
             with open(self.MOCK_FILE_NAME, "r") as f:
                 return json.load(f)
         return {}
 
     def mock_write(self, mock_ids):
         # Write current mocking structure
+        if self.DEBUG_FLAG:
+            self.debug(self.mock_write.__name__, "writing %s"% self.MOCK_FILE_NAME)
         with open(self.MOCK_FILE_NAME, "w") as f:
             f.write(json.dumps(mock_ids, indent=4))
 
@@ -189,11 +193,17 @@ class MbedLsToolsBase:
         # Operations on mocked structure
         if oper == '+':
             mock_ids[mid] = platform_name
+            if self.DEBUG_FLAG:
+                self.debug(self.mock_manufacture_ids.__name__, "mock_ids['%s'] = '%s'"% (mid, platform_name))
         elif oper in ['-', '!']:
             if mid in mock_ids:
                 mock_ids.pop(mid)
+                if self.DEBUG_FLAG:
+                    self.debug(self.mock_manufacture_ids.__name__, "removing '%s' mock"% mid)
             elif mid == '*':
                 mock_ids = {}   # Zero mocking set
+                if self.DEBUG_FLAG:
+                    self.debug(self.mock_manufacture_ids.__name__, "zero mocking set")
 
         self.mock_write(mock_ids)
         return mock_ids
@@ -247,7 +257,7 @@ class MbedLsToolsBase:
         result = []
         mbeds = self.list_mbeds()
         for i, val in enumerate(mbeds):
-            platform_name = val['platform_name']
+            platform_name = str(val['platform_name'])
             if platform_name not in result:
                 result.append(platform_name)
         return result
@@ -259,7 +269,7 @@ class MbedLsToolsBase:
         result = {}
         mbeds = self.list_mbeds()
         for i, val in enumerate(mbeds):
-            platform_name = val['platform_name']
+            platform_name = str(val['platform_name'])
             if platform_name not in result:
                 result[platform_name] = 1
             else:

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -87,6 +87,10 @@ def cmd_parser_setup():
                       action="store_true",
                       help='Parser friendly verbose mode')
 
+    parser.add_option('-m', '--mock',
+                      dest='mock_platform',
+                      help='Add locally manufacturers id and platform name. Example --mock=12B4:NEW_PLATFORM')
+
     parser.add_option('-j', '--json',
                       dest='json',
                       default=False,
@@ -143,7 +147,28 @@ def mbedls_main():
 
     mbeds.DEBUG_FLAG = opts.debug
 
-    if opts.json:
+    if opts.mock_platform:
+        if opts.mock_platform == '*':
+            if opts.json:
+                print json.dumps(mbeds.mock_read(), indent=4)
+
+        for token in opts.mock_platform.split(','):
+            if ':' in token:
+                oper = '+' # Default
+                mid, platform_name = token.split(':')
+                if mid and mid[0] in ['+', '-']:
+                    oper = mid[0]   # Operation (character)
+                    mid = mid[1:]   # We remove operation character
+                mbeds.mock_manufacture_ids(mid, platform_name, oper=oper)
+            elif token and token[0] in ['-', '!']:
+                # Operations where do not specify data after colon: --mock=-1234,-7678
+                oper = token[0]
+                mid = token[1:]
+                mbeds.mock_manufacture_ids(mid, 'dummy', oper=oper)
+        if opts.json:
+            print json.dumps(mbeds.mock_read(), indent=4)
+
+    elif opts.json:
         print json.dumps(mbeds.list_mbeds_ext(), indent=4, sort_keys=True)
 
     elif opts.json_by_target_id:


### PR DESCRIPTION
# Description
Add simple manufacturers ID masking with new platform name.
Mock configuration will be stored in local file ```.mbedls-mock```. You can 

# Rationale
Users should be able to add locally new ```MID``` -> ```platform_name``` mapping when e.g. prototyping.
Note: ```MID```: "manufacturers ID", first 4 characters of taregt_id

## Usage
* Add new command line parameter ```--mock``` (switch -m)
* Add new / mask existing mapping ```MID``` -> ```platform_name``` and assign MID
    * ```$mbedls --mock MID:PLATFORM_NAME``` or
    * ```$mbedls --mock MID1:PLATFORM_NAME1,MID2:PLATFORM_NAME2```
* Mask existing manufacturers ID with new platform name
* Remove masking with '!' prefix
    * ```$ mbedls --mock !MID```
* Remove all maskings using !* notation
    * ```$ mbedls --mock !*```
* Combine above using comma (```,```) separator:
    * ```$mbedls --mock MID1:PLATFORM_NAME1,!MID2```

## Example
Initial setup with 1 x Freescale ```K64F``` board:
```
$ mbedls
+--------------+---------------------+------------+------------+-------------------------+
|platform_name |platform_name_unique |mount_point |serial_port |target_id                |
+--------------+---------------------+------------+------------+-------------------------+
|K64F          |K64F[0]              |F:          |COM146      |02400221A0811E505D5FE3E8 |
+--------------+---------------------+------------+------------+-------------------------+
```

* We can mask current mapping ```0240``` -> ```K64F``` to something else. For example we can replace ```K64F``` name with maybe more suitable for us in current setup ```FRDM-K64F```:
```
$  mbedls --mock 0240:FRDM_K64F
```
Current mocking mapping is stored in local file ```.mbedls-mock```:
```
$  cat .mbedls-mock
{
    "1234": "NEW_PLATFORM_1",
    "0240": "FRDM_K64F"
}
```
We can observe changes immediately. Please note this change only works in the same directory because we save ```.mbedls-mock``` file locally:
```
$  mbedls
+--------------+---------------------+------------+------------+-------------------------+
|platform_name |platform_name_unique |mount_point |serial_port |target_id                |
+--------------+---------------------+------------+------------+-------------------------+
|FRDM_K64F     |FRDM_K64F[0]         |F:          |COM146      |02400221A0811E505D5FE3E8 |
+--------------+---------------------+------------+------------+-------------------------+
```

* We can remove mapping ```1234``` -> Anythying using ```!``` wildcard.
Note: We are using flag ```-json``` to get JSON format output of the ```--mock``` operation.
```
$ mbedls --mock !1234 --json
{
    "0240": "FRDM_K64F"
}
```

* We can add multiple mappings at the same time:
```
$ --mock 0000:DUMMY,1111:DUMMY_2 --json
{
    "1111": "DUMMY_2",
    "0240": "FRDM_K64F",
    "0000": "DUMMY"
}
```

* We can remove (```!```) all mappings using ```*``` wildcard:
```
$ mbedls --mock !*
```

We can verify our mapping is reset:
```
$ cat .mbedls-mock
{}
```