### PR TITLE
Fix problems on Ubuntu

### DIFF
--- a/mbed_lstools/lstools_ubuntu.py
+++ b/mbed_lstools/lstools_ubuntu.py
@@ -88,7 +88,7 @@ class MbedLsToolsUbuntu(MbedLsToolsBase):
         self.ERRORLEVEL_FLAG = 0
 
         result = []
-        tidhex = re.compile(r'_([0-9a-fA-F]+)')
+        tidhex = re.compile(r'_([0-9a-fA-F]+)-\d+:\d+')
         for device in all_devices:
             tid = None
             m = tidhex.search(device[4])
@@ -235,7 +235,7 @@ class MbedLsToolsUbuntu(MbedLsToolsBase):
                     mbed_dev_serial = self.get_mbed_serial(serial_list, dhi)
                     # Print detected device
                     mbed_mount_point = self.get_mount_point(mbed_dev_disk, mount_list)
-                    if mbed_mount_point and  mbed_dev_serial:
+                    if mbed_mount_point:
                         result.append([mbed_name, mbed_dev_disk, mbed_mount_point, mbed_dev_serial, disk_hex_ids[dhi]])
         return result
 


### PR DESCRIPTION
Allow devices with missing a serial port to show up on Ubuntu.  Also
fix regular expression for parsing the ID.  For example the following
string:
"usb-MBED_DAPLINK_VFS_0231023440424e0c000000000000000000000000bd89b3c5-0:0 -> ../../sdb"

Would match with "DA" since those are both valid hex characters
preceded by an underscore.