### PR TITLE
Add support for SEGGER J-Link devices (EFM32) on OSX

### DIFF
--- a/mbed_lstools/lstools_darwin.py
+++ b/mbed_lstools/lstools_darwin.py
@@ -25,7 +25,7 @@ class MbedLsToolsDarwin(MbedLsToolsBase):
     """ MbedLsToolsDarwin supports mbed-enabled platforms detection on Mac OS X
     """
 
-    mbed_volume_name_match = re.compile(r'\bmbed\b', re.I)
+    mbed_volume_name_match = re.compile(r'(\bmbed\b|\bSEGGER MSD\b)', re.I)
 
     def list_mbeds(self):
         """ returns mbed list with platform names if possible


### PR DESCRIPTION
This PR allows the LsToolsDarwin to enumerate SEGGER J-Link-based devices, by also looking for "SEGGER MSD" in the IORegistryEntryName. Tested and found to work with EFM32GG_STK3700 with mbedls standalone, and also with mbedgt/mbed-htrun (yotta test).

@PrzemekWirkus 