### PR TITLE
detect multiple mount points in ubuntu

### DIFF
--- a/mbed_lstools/lstools_ubuntu.py
+++ b/mbed_lstools/lstools_ubuntu.py
@@ -302,7 +302,7 @@ class MbedLsToolsUbuntu(MbedLsToolsBase):
 
         @details
         """
-        mount_media_pattern = "^/[a-zA-Z0-9/]*/" + dev_name  + " on (/[a-zA-Z0-9/]*) "
+        mount_media_pattern = "^/[a-zA-Z0-9/]*/" + dev_name  + " on (/[a-zA-Z0-9_/]*) "
         mmp = re.compile(mount_media_pattern)
         for mount in mount_list:
             m = mmp.search(mount)


### PR DESCRIPTION
when multiple devices are connected to ubuntu host mount point will be following:
```
/media/MBED_ for second device
/media/MBED__ for third device and so on...
/media/MBED______ ... .
```

This PR should fix mbed detection problems when multiple devices are connected.