### PR TITLE
Extended mount point naming convention

### DIFF
--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -300,9 +300,12 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         @param dev_name Device name (e.g 'sda')
         @param mount_list List of all mounted devices (strings from Linux mount shell command)
 
-        @details
+        @details We want to scan names of mount points like this:
+        /media/MBED_xxx
+        /media/MBED__xxx
+        /media/MBED-xxx
         """
-        mount_media_pattern = "^/[a-zA-Z0-9/]*/" + dev_name  + " on (/[a-zA-Z0-9/]*) "
+        mount_media_pattern = "^/[a-zA-Z0-9/]*/" + dev_name  + " on (/[a-zA-Z0-9_\-/]*) "
         mmp = re.compile(mount_media_pattern)
         for mount in mount_list:
             m = mmp.search(mount)

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -25,7 +25,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
     """ MbedLsToolsLinuxGeneric supports mbed-enabled platforms detection across Linux family
     """
     def __init__(self):
-        """ ctor
+        """！ ctor
         """
         MbedLsToolsBase.__init__(self)
         self.os_supported.append('LinuxGeneric')
@@ -35,11 +35,8 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def list_mbeds(self):
         """! Returns detailed list of connected mbeds
-
         @return Returns list of structures with detailed info about each mbed
-
         @details Function returns list of dictionaries with mbed attributes such as mount point, TargetID name etc.
-
         Function returns mbed list with platform names if possible
         all_devices =
         [
@@ -122,9 +119,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def get_dev_by_id(self, subdir):
         """! Lists disk devices by id
-
         @return List of strings from 'ls' command executed in shell
-
         @details Uses Linux shell command: 'ls -oA /dev/disk/by-id/'
         """
         result = []
@@ -143,9 +138,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def get_mounts(self):
         """! Lists mounted devices with vfat file system (potential mbeds)
-
         @result Returns list of all mounted vfat devices
-
         @details Uses Linux shell command: 'mount | grep vfat'
         """
         result = []
@@ -164,11 +157,8 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def get_disk_hex_ids(self, disk_list):
         """! Get only hexadecimal IDs for mbed disks
-
         @param disk_list List of disks in a system with USBID decoration
-
         @return Returns map of disks and corresponding disks' Hex ids
-
         @details Uses regular expressions to get Hex strings (TargeTIDs) from list of disks
         """
         nlp = re.compile(self.name_link_pattern)
@@ -185,12 +175,9 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def get_mbed_serial(self, serial_list, dhi):
         """! Get mbed serial by unique hex id (dhi) in disk name
-
-        @return Returns None if corresponding serial device is not found, else returns serial device path
-
         @param serial_list List of all serial ports
         @param dhi Unique Hex id of possible mbed device
-
+        @return Returns None if corresponding serial device is not found, else returns serial device path
         @details Devices are located in Linux '/dev/' directory structure
         """
         nlp = re.compile(self.name_link_pattern)
@@ -205,14 +192,11 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def get_detected(self, tids, disk_list, serial_list, mount_list):
         """! Find all known mbed devices and assign name by targetID
-
-        @return list of lists [mbed_name, mbed_dev_disk, mbed_mount_point, mbed_dev_serial, disk_hex_id]
-
         @param tids TargetID comprehensive list for detection (manufacturers_ids)
         @param disk_list List of disks (mount points in /dev/disk)
         @param serial_list List of serial devices (serial ports in /dev/serial)
         @param mount_list List of lines from 'mount' command
-
+        @return list of lists [mbed_name, mbed_dev_disk, mbed_mount_point, mbed_dev_serial, disk_hex_id]
         @details Find for all disk connected all MBED ones we know about from TID list
         """
         # Find for all disk connected all MBED ones we know about from TID list
@@ -241,14 +225,11 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
 
     def get_not_detected(self, tids, disk_list, serial_list, mount_list):
         """! Find all unknown mbed-enabled devices (may have 'mbed' string in USBID name)
-
-        @return list of lists [mbed_name, mbed_dev_disk, mbed_mount_point, mbed_dev_serial, disk_hex_id]
-
         @param tids TargetID comprehensive list for detection (manufacturers_ids)
         @param disk_list List of disks (mount points in /dev/disk)
         @param serial_list List of serial devices (serial ports in /dev/serial)
         @param mount_list List of lines from 'mount' command
-
+        @return list of lists [mbed_name, mbed_dev_disk, mbed_mount_point, mbed_dev_serial, disk_hex_id]
         @details Find for all disk connected all MBED ones we know about from TID list
         """
         map_tid_to_mbed = self.get_tid_mbed_name_remap(tids)
@@ -279,12 +260,12 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         return result
 
     def get_tid_mbed_name_remap(self, tids):
-        """ Remap to get mapping:  ID -> mbed name
+        """！ Remap to get mapping:  ID -> mbed name
         """
         return tids
 
     def get_dev_name(self, link):
-        """ Get device name from symbolic link list
+        """！ Get device name from symbolic link list
         """
         device_sufix_pattern = ".*/([a-zA-Z0-9]*)$"
         dsp = re.compile(device_sufix_pattern)
@@ -293,13 +274,10 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         return mbed_dev
 
     def get_mount_point(self, dev_name, mount_list):
-        """ Find mount points for MBED devices using mount command output
-
-        @return Returns None if mount point not found. Else returns device mount path
-
+        """！ Find mount points for MBED devices using mount command output
         @param dev_name Device name (e.g 'sda')
         @param mount_list List of all mounted devices (strings from Linux mount shell command)
-
+        @return Returns None if mount point not found. Else returns device mount path
         @details We want to scan names of mount points like this:
         /media/MBED_xxx
         /media/MBED__xxx

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -25,7 +25,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
     """ MbedLsToolsLinuxGeneric supports mbed-enabled platforms detection across Linux family
     """
     def __init__(self):
-        """！ ctor
+        """! ctor
         """
         MbedLsToolsBase.__init__(self)
         self.os_supported.append('LinuxGeneric')

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -260,12 +260,12 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         return result
 
     def get_tid_mbed_name_remap(self, tids):
-        """！ Remap to get mapping:  ID -> mbed name
+        """! Remap to get mapping:  ID -> mbed name
         """
         return tids
 
     def get_dev_name(self, link):
-        """！ Get device name from symbolic link list
+        """! Get device name from symbolic link list
         """
         device_sufix_pattern = ".*/([a-zA-Z0-9]*)$"
         dsp = re.compile(device_sufix_pattern)
@@ -274,7 +274,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         return mbed_dev
 
     def get_mount_point(self, dev_name, mount_list):
-        """！ Find mount points for MBED devices using mount command output
+        """! Find mount points for MBED devices using mount command output
         @param dev_name Device name (e.g 'sda')
         @param mount_list List of all mounted devices (strings from Linux mount shell command)
         @return Returns None if mount point not found. Else returns device mount path

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -30,7 +30,7 @@ class BasicTestCase(unittest.TestCase):
 
     def setUp(self):
         self.linux_generic = MbedLsToolsLinuxGeneric()
-        
+
         self.vfat_devices = [
             "/dev/sdb on /media/usb0 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
             "/dev/sdd on /media/usb2 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
@@ -57,12 +57,22 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual('/media/usb2', self.linux_generic.get_mount_point('sdd', self.vfat_devices))
         self.assertEqual('/media/usb3', self.linux_generic.get_mount_point('sde', self.vfat_devices))
         self.assertEqual('/media/usb1', self.linux_generic.get_mount_point('sdc', self.vfat_devices))
-        
+
     def test_get_mount_point_ext(self):
         self.assertEqual('/media/MBED_xxx', self.linux_generic.get_mount_point('sdb', self.vfat_devices_ext))
         self.assertEqual('/media/MBED___x', self.linux_generic.get_mount_point('sdd', self.vfat_devices_ext))
         self.assertEqual('/media/MBED-xxx', self.linux_generic.get_mount_point('sde', self.vfat_devices_ext))
         self.assertEqual('/media/MBED_x-x', self.linux_generic.get_mount_point('sdc', self.vfat_devices_ext))
-        
+
+    def test_get_dev_name(self):
+        self.assertEqual('ttyACM0', self.linux_generic.get_dev_name('usb-MBED_MBED_CMSIS-DAP_02400201489A1E6CB564E3D4-if01 -> ../../ttyACM0'))
+        self.assertEqual('ttyACM2', self.linux_generic.get_dev_name('usb-STMicroelectronics_STM32_STLink_0672FF485649785087171742-if02 -> ../../ttyACM2'))
+        self.assertEqual('ttyACM3', self.linux_generic.get_dev_name('usb-MBED_MBED_CMSIS-DAP_0240020152986E5EAF6693E6-if01 -> ../../ttyACM3'))
+        self.assertEqual('ttyACM2', self.linux_generic.get_dev_name('/dev/ttyACM2'))
+        self.assertEqual('sdb', self.linux_generic.get_dev_name('usb-MBED_microcontroller_02400201489A1E6CB564E3D4-0:0 -> ../../sdb'))
+        self.assertEqual('sde', self.linux_generic.get_dev_name('usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sde'))
+        self.assertEqual('sdd', self.linux_generic.get_dev_name('usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd'))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import os
+import errno
+import logging
+from mbed_lstools.lstools_linux_generic import MbedLsToolsLinuxGeneric
+
+
+
+class BasicTestCase(unittest.TestCase):
+    """ Basic test cases checking trivial asserts
+    """
+
+    def setUp(self):
+        self.linux_generic = MbedLsToolsLinuxGeneric()
+        
+        self.vfat_devices = [
+            "/dev/sdb on /media/usb0 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+            "/dev/sdd on /media/usb2 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+            "/dev/sde on /media/usb3 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+            "/dev/sdc on /media/usb1 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)"
+        ]
+
+        self.vfat_devices_ext = [
+            "/dev/sdb on /media/MBED_xxx type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+            "/dev/sdd on /media/MBED___x type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+            "/dev/sde on /media/MBED-xxx type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+            "/dev/sdc on /media/MBED_x-x type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)"
+        ]
+
+    def tearDown(self):
+        pass
+
+    def test_example(self):
+        self.assertEqual(True, True)
+        self.assertNotEqual(True, False)
+
+    def test_get_mount_point_basic(self):
+        self.assertEqual('/media/usb0', self.linux_generic.get_mount_point('sdb', self.vfat_devices))
+        self.assertEqual('/media/usb2', self.linux_generic.get_mount_point('sdd', self.vfat_devices))
+        self.assertEqual('/media/usb3', self.linux_generic.get_mount_point('sde', self.vfat_devices))
+        self.assertEqual('/media/usb1', self.linux_generic.get_mount_point('sdc', self.vfat_devices))
+        
+    def test_get_mount_point_ext(self):
+        self.assertEqual('/media/MBED_xxx', self.linux_generic.get_mount_point('sdb', self.vfat_devices_ext))
+        self.assertEqual('/media/MBED___x', self.linux_generic.get_mount_point('sdd', self.vfat_devices_ext))
+        self.assertEqual('/media/MBED-xxx', self.linux_generic.get_mount_point('sde', self.vfat_devices_ext))
+        self.assertEqual('/media/MBED_x-x', self.linux_generic.get_mount_point('sdc', self.vfat_devices_ext))
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Simple change to add ```-``` and ```_``` to mount point name to avoid unnecessary name filtering.
This PR is extension to this one: https://github.com/ARMmbed/mbed-ls/pull/33