### PR TITLE
[Linux] Linux detection ignores undefined target ids

### DIFF
--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -232,24 +232,24 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         @return list of lists [mbed_name, mbed_dev_disk, mbed_mount_point, mbed_dev_serial, disk_hex_id]
         @details Find for all disk connected all MBED ones we know about from TID list
         """
+        disk_hex_ids = self.get_disk_hex_ids(disk_list)
+
         map_tid_to_mbed = self.get_tid_mbed_name_remap(tids)
-        orphan_mbeds = []
-        for disk in disk_list:
-            if "mbed" in disk.lower():
+        orphan_mbeds = {}
+        for disk in disk_hex_ids:
+            if "mbed" in disk_hex_ids[disk].lower():
                 orphan_found = True
                 for tid in map_tid_to_mbed.keys():
-                    if tid in disk:
+                    if disk.startswith(tid):
                         orphan_found = False
                         break
                 if orphan_found:
-                    orphan_mbeds.append(disk)
+                    orphan_mbeds[disk] = disk_hex_ids[disk]
 
         # Search for corresponding MBED serial
-        disk_hex_ids = self.get_disk_hex_ids(orphan_mbeds)
-
         result = []
-        # FInd orphan serial name
-        for dhi in disk_hex_ids:
+        # Find orphan serial name
+        for dhi in orphan_mbeds:
             orphan_serial = self.get_mbed_serial(serial_list, dhi)
             if orphan_serial:
                 orphan_dev_disk = self.get_dev_name(disk_hex_ids[dhi])

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -33,6 +33,9 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         self.name_link_pattern = "(usb-[0-9a-zA-Z_-]*_[0-9a-zA-Z]*-.*$)"
         self.mount_media_pattern = "^/[a-zA-Z0-9/]* on (/[a-zA-Z0-9/]*) "
 
+        self.nlp = re.compile(self.name_link_pattern)
+        self.hup = re.compile(self.hex_uuid_pattern)
+
     def list_mbeds(self):
         """! Returns detailed list of connected mbeds
         @return Returns list of structures with detailed info about each mbed
@@ -174,14 +177,12 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         @return Returns map of disks and corresponding disks' Hex ids
         @details Uses regular expressions to get Hex strings (TargeTIDs) from list of disks
         """
-        nlp = re.compile(self.name_link_pattern)
-        hup = re.compile(self.hex_uuid_pattern)
         disk_hex_ids = {}
         for dl in disk_list:
-            m = nlp.search(dl)
+            m = self.nlp.search(dl)
             if m and len(m.groups()):
                 disk_link = m.group(1)
-                m = hup.search(disk_link)
+                m = self.hup.search(disk_link)
                 if m and len(m.groups()):
                     disk_hex_ids[m.group(1)] = disk_link
         return disk_hex_ids
@@ -193,10 +194,9 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         @return Returns None if corresponding serial device is not found, else returns serial device path
         @details Devices are located in Linux '/dev/' directory structure
         """
-        nlp = re.compile(self.name_link_pattern)
         for sl in serial_list:
             if dhi in sl:
-                m = nlp.search(sl)
+                m = self.nlp.search(sl)
                 if m and len(m.groups()):
                     serial_link = m.group(1)
                     mbed_dev_serial = "/dev/" + self.get_dev_name(serial_link)

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -17,14 +17,11 @@ limitations under the License.
 """
 
 import unittest
-import os
-import errno
-import logging
+from mbed_lstools.lstools_ubuntu import MbedLsToolsUbuntu
 from mbed_lstools.lstools_linux_generic import MbedLsToolsLinuxGeneric
 
 
-
-class BasicTestCase(unittest.TestCase):
+class LinuxPortTestCase(unittest.TestCase):
     """ Basic test cases checking trivial asserts
     """
 
@@ -45,12 +42,96 @@ class BasicTestCase(unittest.TestCase):
             "/dev/sdc on /media/MBED_x-x type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)"
         ]
 
+        # get_detected / get_not_detected (1 missing lpc1768)
+
+        self.tids = {
+            "0001": "LPC2368",
+            "0002": "LPC2368",
+            "0240": "FRDM_K64F",        # Under test
+            "0245": "FRDM_K64F",
+            "1010": "LPC1768",          # Under test
+            "0715": "NUCLEO_L053R8",
+            "0720": "NUCLEO_F401RE",    # Under test
+            "0725": "NUCLEO_F030R8",
+        }
+
+        self.disk_list_1 = [
+          "total 0",
+          "lrwxrwxrwx 1 root  9 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM -> ../../sda",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part1 -> ../../sda1",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part2 -> ../../sda2",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part5 -> ../../sda5",
+          "lrwxrwxrwx 1 root  9 Dec 11 14:18 ata-TSSTcorpDVD-ROM_TS-H352C -> ../../sr0",
+          "lrwxrwxrwx 1 root  9 Jan  4 15:01 usb-MBED_FDi_sk_A000000001-0:0 -> ../../sdc",
+          "lrwxrwxrwx 1 root  9 Jan  4 15:01 usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb",
+          "lrwxrwxrwx 1 root  9 Dec 11 14:18 wwn-0x5000cca30ccffb77 -> ../../sda",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part1 -> ../../sda1",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part2 -> ../../sda2",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part5 -> ../../sda5"
+        ]
+
+        self.serial_list_1 = [
+          "total 0",
+          "lrwxrwxrwx 1 root 13 Jan  4 15:01 usb-MBED_MBED_CMSIS-DAP_0240020152986E5EAF6693E6-if01 -> ../../ttyACM1",
+          "lrwxrwxrwx 1 root 13 Jan  4 15:01 usb-MBED_MBED_CMSIS-DAP_A000000001-if01 -> ../../ttyACM0"
+        ]
+
+        self.mount_list_1 = [
+          "/dev/sdb on /media/usb0 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+          "/dev/sdc on /media/usb1 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)"
+        ]
+
+        # get_detected / get_not_detected (1 missing lpc1768, more platforms)
+        # +--------------+---------------------+------------+-------------+-------------------------+
+        # |platform_name |platform_name_unique |mount_point |serial_port  |target_id                |
+        # +--------------+---------------------+------------+-------------+-------------------------+
+        # |K64F          |K64F[0]              |/media/usb4 |/dev/ttyACM4 |0240020152A06E54AF5E93EC |
+        # |K64F          |K64F[1]              |/media/usb3 |/dev/ttyACM3 |02400201489A1E6CB564E3D4 |
+        # |K64F          |K64F[2]              |/media/usb0 |/dev/ttyACM1 |0240020152986E5EAF6693E6 |
+        # |NUCLEO_F401RE |NUCLEO_F401RE[0]     |/media/usb2 |/dev/ttyACM2 |07200200076165023804F31F |
+        # |LPC1768       |LPC1768[0]           |/media/usb1 |/dev/ttyACM5 |A000000001               |
+        # +--------------+---------------------+------------+-------------+-------------------------+
+
+        self.disk_list_2 = [
+          "total 0",
+          "lrwxrwxrwx 1 root  9 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM -> ../../sda",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part1 -> ../../sda1",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part2 -> ../../sda2",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part5 -> ../../sda5",
+          "lrwxrwxrwx 1 root  9 Dec 11 14:18 ata-TSSTcorpDVD-ROM_TS-H352C -> ../../sr0",
+          "lrwxrwxrwx 1 root  9 Jan  4 15:01 usb-MBED_FDi_sk_A000000001-0:0 -> ../../sdc",
+          "lrwxrwxrwx 1 root  9 Jan  5 07:47 usb-MBED_microcontroller_02400201489A1E6CB564E3D4-0:0 -> ../../sde",
+          "lrwxrwxrwx 1 root  9 Jan  4 15:01 usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb",
+          "lrwxrwxrwx 1 root  9 Jan  5 07:49 usb-MBED_microcontroller_0240020152A06E54AF5E93EC-0:0 -> ../../sdf",
+          "lrwxrwxrwx 1 root  9 Jan  5 07:47 usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd",
+          "lrwxrwxrwx 1 root  9 Dec 11 14:18 wwn-0x5000cca30ccffb77 -> ../../sda",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part1 -> ../../sda1",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part2 -> ../../sda2",
+          "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part5 -> ../../sda5"
+        ]
+
+        self.serial_list_2 = [
+          "total 0",
+          "lrwxrwxrwx 1 root 13 Jan  5 07:47 usb-MBED_MBED_CMSIS-DAP_02400201489A1E6CB564E3D4-if01 -> ../../ttyACM3",
+          "lrwxrwxrwx 1 root 13 Jan  4 15:01 usb-MBED_MBED_CMSIS-DAP_0240020152986E5EAF6693E6-if01 -> ../../ttyACM1",
+          "lrwxrwxrwx 1 root 13 Jan  5 07:49 usb-MBED_MBED_CMSIS-DAP_0240020152A06E54AF5E93EC-if01 -> ../../ttyACM4",
+          "lrwxrwxrwx 1 root 13 Jan  4 15:01 usb-MBED_MBED_CMSIS-DAP_A000000001-if01 -> ../../ttyACM0",
+          "lrwxrwxrwx 1 root 13 Jan  5 07:47 usb-STMicroelectronics_STM32_STLink_0672FF485649785087171742-if02 -> ../../ttyACM2"
+        ]
+
+        self.mount_list_2 = [
+          "/dev/sdb on /media/usb0 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+          "/dev/sdc on /media/usb1 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+          "/dev/sdd on /media/usb2 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+          "/dev/sde on /media/usb3 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)",
+          "/dev/sdf on /media/usb4 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)"
+        ]
+
     def tearDown(self):
         pass
 
-    def test_example(self):
-        self.assertEqual(True, True)
-        self.assertNotEqual(True, False)
+    def test_ubuntu_construction(self):
+        self.linux_ubuntu = MbedLsToolsUbuntu()
 
     def test_get_mount_point_basic(self):
         self.assertEqual('/media/usb0', self.linux_generic.get_mount_point('sdb', self.vfat_devices))
@@ -73,6 +154,134 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual('sde', self.linux_generic.get_dev_name('usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sde'))
         self.assertEqual('sdd', self.linux_generic.get_dev_name('usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd'))
 
+    def test_get_detected_1_k64f(self):
+        # get_detected(self, tids, disk_list, serial_list, mount_list)
+
+        mbed_det = self.linux_generic.get_detected(self.tids,
+            self.disk_list_1,
+            self.serial_list_1,
+            self.mount_list_1)
+
+        self.assertEqual(1, len(mbed_det))
+        self.assertIn([
+            "FRDM_K64F",
+            "sdb",
+            "/media/usb0",
+            "/dev/ttyACM1",
+            "usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb"
+          ],
+          mbed_det)
+
+    def test_get_not_detected_1_unknown_lpc1768(self):
+        # LPC1768 with weird target id like this:
+        mbed_ndet = self.linux_generic.get_not_detected(self.tids,
+            self.disk_list_1,
+            self.serial_list_1,
+            self.mount_list_1)
+
+        self.assertEqual(1, len(mbed_ndet))
+        self.assertIn([
+            None,
+            "sdc",
+            "/media/usb1",
+            "/dev/ttyACM0",
+            "usb-MBED_FDi_sk_A000000001-0:0 -> ../../sdc"
+          ],
+          mbed_ndet)
+
+    def test_get_detected_2_k64f(self):
+        # get_detected(self, tids, disk_list, serial_list, mount_list)
+
+        mbed_det = self.linux_generic.get_detected(self.tids,
+            self.disk_list_2,
+            self.serial_list_2,
+            self.mount_list_2)
+
+        self.assertEqual(3, len(mbed_det))
+        self.assertIn([
+            "FRDM_K64F",
+            "sdf",
+            "/media/usb4",
+            "/dev/ttyACM4",
+            "usb-MBED_microcontroller_0240020152A06E54AF5E93EC-0:0 -> ../../sdf"
+          ],
+          mbed_det)
+
+        self.assertIn([
+            "FRDM_K64F",
+            "sde",
+            "/media/usb3",
+            "/dev/ttyACM3",
+            "usb-MBED_microcontroller_02400201489A1E6CB564E3D4-0:0 -> ../../sde"
+          ],
+          mbed_det)
+
+        self.assertIn([
+            "FRDM_K64F",
+            "sdb",
+            "/media/usb0",
+            "/dev/ttyACM1",
+            "usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb"
+          ],
+          mbed_det)
+
+    def test_get_not_detected_2_unknown_lpc1768_stf401(self):
+        # LPC1768 with weird target id like this:
+        mbed_ndet = self.linux_generic.get_not_detected(self.tids,
+            self.disk_list_2,
+            self.serial_list_2,
+            self.mount_list_2)
+
+        self.assertEqual(2, len(mbed_ndet))
+
+        self.assertIn([
+            None,
+            "sdc",
+            "/media/usb1",
+            "/dev/ttyACM0",
+            "usb-MBED_FDi_sk_A000000001-0:0 -> ../../sdc"
+          ],
+          mbed_ndet)
+
+        self.assertIn([
+            None,
+            "sdd",
+            "/media/usb2",
+            "/dev/ttyACM2",
+            "usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd"
+          ],
+          mbed_ndet)
+
+    def test_get_disk_hex_ids_1(self):
+        disk_hex_ids = self.linux_generic.get_disk_hex_ids(self.disk_list_1)
+        self.assertEqual(2, len(disk_hex_ids))
+
+        hex_keys = disk_hex_ids.keys()
+        self.assertIn("A000000001", hex_keys)
+        self.assertIn("0240020152986E5EAF6693E6", hex_keys)
+
+        hex_values = disk_hex_ids.values()
+        self.assertIn("usb-MBED_FDi_sk_A000000001-0:0 -> ../../sdc", hex_values)
+        self.assertIn("usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb", hex_values)
+
+    def test_get_disk_hex_ids_2(self):
+        disk_hex_ids = self.linux_generic.get_disk_hex_ids(self.disk_list_2)
+        self.assertEqual(5, len(disk_hex_ids))
+
+        # Checking for scanned target ids (in dict keys)
+        hex_keys = disk_hex_ids.keys()
+        self.assertIn("A000000001", hex_keys)
+        self.assertIn("0240020152A06E54AF5E93EC", hex_keys)
+        self.assertIn("0672FF485649785087171742", hex_keys)
+        self.assertIn("02400201489A1E6CB564E3D4", hex_keys)
+        self.assertIn("0240020152986E5EAF6693E6", hex_keys)
+
+        hex_values = disk_hex_ids.values()
+        self.assertIn("usb-MBED_FDi_sk_A000000001-0:0 -> ../../sdc", hex_values)
+        self.assertIn("usb-MBED_microcontroller_0240020152A06E54AF5E93EC-0:0 -> ../../sdf", hex_values)
+        self.assertIn("usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd", hex_values)
+        self.assertIn("usb-MBED_microcontroller_02400201489A1E6CB564E3D4-0:0 -> ../../sde", hex_values)
+        self.assertIn("usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb", hex_values)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -88,9 +88,19 @@ class LinuxPortTestCase(unittest.TestCase):
         # |K64F          |K64F[0]              |/media/usb4 |/dev/ttyACM4 |0240020152A06E54AF5E93EC |
         # |K64F          |K64F[1]              |/media/usb3 |/dev/ttyACM3 |02400201489A1E6CB564E3D4 |
         # |K64F          |K64F[2]              |/media/usb0 |/dev/ttyACM1 |0240020152986E5EAF6693E6 |
+        # |LPC1768       |LPC1768[0]           |/media/usb1 |/dev/ttyACM0 |A000000001               |
         # |NUCLEO_F401RE |NUCLEO_F401RE[0]     |/media/usb2 |/dev/ttyACM2 |07200200076165023804F31F |
-        # |LPC1768       |LPC1768[0]           |/media/usb1 |/dev/ttyACM5 |A000000001               |
         # +--------------+---------------------+------------+-------------+-------------------------+
+        # After read from MBED.HTM:
+        # +--------------+---------------------+------------+-------------+------------------------------------------------------------------------+
+        # |platform_name |platform_name_unique |mount_point |serial_port  |target_id                                                               |
+        # +--------------+---------------------+------------+-------------+------------------------------------------------------------------------+
+        # |K64F          |K64F[0]              |/media/usb4 |/dev/ttyACM4 |0240020152A06E54AF5E93EC                                                |
+        # |K64F          |K64F[1]              |/media/usb3 |/dev/ttyACM3 |02400201489A1E6CB564E3D4                                                |
+        # |K64F          |K64F[2]              |/media/usb0 |/dev/ttyACM1 |0240020152986E5EAF6693E6                                                |
+        # |LPC1768       |LPC1768[0]           |/media/usb1 |/dev/ttyACM0 |101000000000000000000002F7F0D9F98dbdc24b9e28ac87cfc4f23c4c57438d        |
+        # |NUCLEO_F401RE |NUCLEO_F401RE[0]     |/media/usb2 |/dev/ttyACM2 |07200200076165023804F31F                                                |
+        # +--------------+---------------------+------------+-------------+------------------------------------------------------------------------+
 
         self.disk_list_2 = [
           "total 0",

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -136,6 +136,31 @@ class LinuxPortTestCase(unittest.TestCase):
           "/dev/sdf on /media/usb4 type vfat (rw,noexec,nodev,sync,noatime,nodiratime,gid=1000,uid=1000,dmask=000,fmask=000)"
         ]
 
+        self.disk_list_3 = [
+            "total 0",
+            "lrwxrwxrwx 1 root 13 Jan  5 09:41 usb-MBED_MBED_CMSIS-DAP_0240020152986E5EAF6693E6-if01 -> ../../ttyACM0",
+            "lrwxrwxrwx 1 root 13 Jan  5 10:00 usb-MBED_MBED_CMSIS-DAP_0240020152A06E54AF5E93EC-if01 -> ../../ttyACM3",
+            "lrwxrwxrwx 1 root 13 Jan  5 10:00 usb-MBED_MBED_CMSIS-DAP_107002001FE6E019E2190F91-if01 -> ../../ttyACM1",
+            "lrwxrwxrwx 1 root 13 Jan  5 10:00 usb-STMicroelectronics_STM32_STLink_0672FF485649785087171742-if02 -> ../../ttyACM2",
+        ]
+
+        self.serial_list_3 = [
+            "total 0",
+            "lrwxrwxrwx 1 root  9 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM -> ../../sda",
+            "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part1 -> ../../sda1",
+            "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part2 -> ../../sda2",
+            "lrwxrwxrwx 1 root 10 Dec 11 14:18 ata-HDS728080PLA380_40Y9028LEN_PFDB32S7S44XLM-part5 -> ../../sda5",
+            "lrwxrwxrwx 1 root  9 Dec 11 14:18 ata-TSSTcorpDVD-ROM_TS-H352C -> ../../sr0",
+            "lrwxrwxrwx 1 root  9 Jan  5 09:41 usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb",
+            "lrwxrwxrwx 1 root  9 Jan  5 10:00 usb-MBED_microcontroller_0240020152A06E54AF5E93EC-0:0 -> ../../sde",
+            "lrwxrwxrwx 1 root  9 Jan  5 10:00 usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd",
+            "lrwxrwxrwx 1 root  9 Jan  5 10:00 usb-MBED_microcontroller_107002001FE6E019E2190F91-0:0 -> ../../sdc",
+            "lrwxrwxrwx 1 root  9 Dec 11 14:18 wwn-0x5000cca30ccffb77 -> ../../sda",
+            "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part1 -> ../../sda1",
+            "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part2 -> ../../sda2",
+            "lrwxrwxrwx 1 root 10 Dec 11 14:18 wwn-0x5000cca30ccffb77-part5 -> ../../sda5",
+        ]
+
     def tearDown(self):
         pass
 
@@ -291,6 +316,28 @@ class LinuxPortTestCase(unittest.TestCase):
         self.assertIn("usb-MBED_microcontroller_0672FF485649785087171742-0:0 -> ../../sdd", hex_values)
         self.assertIn("usb-MBED_microcontroller_02400201489A1E6CB564E3D4-0:0 -> ../../sde", hex_values)
         self.assertIn("usb-MBED_microcontroller_0240020152986E5EAF6693E6-0:0 -> ../../sdb", hex_values)
+
+    def test_get_dev_by_id_process_ret_0(self):
+        id_disks = self.linux_generic.get_dev_by_id_process(self.disk_list_3, 0)
+        id_serial = self.linux_generic.get_dev_by_id_process(self.serial_list_3, 0)
+
+        self.assertEqual(4, len(id_disks))
+        self.assertEqual(13, len(id_serial))
+        self.assertNotIn("total 0", id_disks)
+        self.assertNotIn("Total 0", id_disks)
+        self.assertNotIn("total 0", id_serial)
+        self.assertNotIn("Total 0", id_serial)
+
+    def test_get_dev_by_id_process_ret_non_zero(self):
+        id_disks = self.linux_generic.get_dev_by_id_process(self.disk_list_3, -1)
+        id_serial = self.linux_generic.get_dev_by_id_process(self.serial_list_3, -1)
+
+        self.assertEqual([], id_disks)
+        self.assertEqual([], id_serial)
+
+    def test_(self):
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -17,7 +17,6 @@ limitations under the License.
 """
 
 import unittest
-from mbed_lstools.lstools_ubuntu import MbedLsToolsUbuntu
 from mbed_lstools.lstools_linux_generic import MbedLsToolsLinuxGeneric
 
 
@@ -140,8 +139,8 @@ class LinuxPortTestCase(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_ubuntu_construction(self):
-        self.linux_ubuntu = MbedLsToolsUbuntu()
+    def test_os_support(self):
+        self.assertIn("LinuxGeneric", self.linux_generic.os_supported)
 
     def test_get_mount_point_basic(self):
         self.assertEqual('/media/usb0', self.linux_generic.get_mount_point('sdb', self.vfat_devices))

--- a/test/os_linux_ubuntu.py
+++ b/test/os_linux_ubuntu.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from mbed_lstools.lstools_ubuntu import MbedLsToolsUbuntu
+
+class UbuntuPortTestCase(unittest.TestCase):
+    """ Basic test cases checking trivial asserts
+    """
+
+    def setUp(self):
+        self.linux_ubuntu = MbedLsToolsUbuntu()
+
+    def tearDown(self):
+        pass
+
+    def test_os_support(self):
+        self.assertIn("Ubuntu", self.linux_ubuntu.os_supported)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix for issue https://github.com/ARMmbed/mbed-ls/issues/36.
When mbed devices' target id was not on target ID predefined list it was omitted.