### PR TITLE
OS X El Capitan not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,3 +426,6 @@ Ran 18 tests in 0.302s
 
 OK
 ```
+
+# Known issues
+* [mbedls fails to list devices on OS X El Capitan](https://github.com/ARMmbed/mbed-ls/issues/38).


### PR DESCRIPTION
* Added chapter "Known issues".
* Notes for known issues related to problems with listing devices on OS X El Capitan..