### PR TITLE
Serialnumber regex fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ lrwxrwxrwx root  10 Dec  3 09:10 wwn-0x5000cca30ccffb77-part5 -> ../../sda5
 
 ***Note:*** ```mbed-ls``` tools pair only serial ports and mount points (not CMSIS-DAP - yet).
 
-We can see that on our host machine (running Ubuntu) there are many 'disk type' devices visible under ```/dev/disk```. The mbed boards can be distinguished and filtered by their unique ```USB-ID``` conventions. In our case, we can see pairs of ```usb-ids``` in both ```/dev/serial/usb-id``` and ```/dev/disk/usb-id``` with embedded ``` TargetID```.  ```TargetID``` can be filtered out, for example using this sudo-regexpr: ```(“MBED”|”mbed”|”STMicro”)_([a-zA-z_-]+)_([a-fA_F0-0]){4,}```
+We can see that on our host machine (running Ubuntu) there are many 'disk type' devices visible under ```/dev/disk```. The mbed boards can be distinguished and filtered by their unique ```USB-ID``` conventions. In our case, we can see pairs of ```usb-ids``` in both ```/dev/serial/usb-id``` and ```/dev/disk/usb-id``` with embedded ``` TargetID```.  ```TargetID``` can be filtered out, for example using this sudo-regexpr: ```(“MBED”|”mbed”|”STMicro”)_([a-zA-z_-]+)_([a-zA-Z0-9]){4,}```
 
 For example, we can match the board 066EFF525257775087141721 by connecting a few dots:
 

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -88,10 +88,10 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         self.ERRORLEVEL_FLAG = 0
 
         result = []
-        tidhex = re.compile(r'_([0-9a-fA-F]+)-\d+:\d+')
+        tidpattern = re.compile(r'_([0-9a-zA-Z]+)-\d+:\d+')
         for device in all_devices:
             tid = None
-            m = tidhex.search(device[4])
+            m = tidpattern.search(device[4])
             if m and len(m.groups()):
                 tid = m.group(1)
             mbed = {'mount_point' : device[2],

--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -157,7 +157,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         for mbed in self.get_mbed_devices():
             mountpoint = re.match('.*\\\\(.:)$', mbed[0]).group(1)
             # TargetID is a hex string with 10-48 chars
-            tid = re.search('[0-9A-Fa-f]{10,48}', mbed[1]).group(0)
+            tid = re.search('[0-9A-Za-z]{10,48}', mbed[1]).group(0)
             mbeds += [(mountpoint, tid)]
             if self.DEBUG_FLAG:
                 self.debug(self.get_mbeds.__name__, (mountpoint, tid))

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -19,6 +19,12 @@ limitations under the License.
 import unittest
 from mbed_lstools.lstools_win7 import MbedLsToolsWin7
 
+# Since we don't have mock, let's monkey-patch
+
+def get_mbed_devices_new(self):
+    return [
+        ('\\DosDevices\\D:', '_??_USBSTOR#Disk&Ven_MBED&Prod_XPRO&Rev_1.00#9&35913356&0&ATML2127031800007973&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'),
+    ]
 
 class Win7TestCase(unittest.TestCase):
     """ Basic test cases checking trivial asserts
@@ -29,6 +35,24 @@ class Win7TestCase(unittest.TestCase):
 
     def test_os_supported(self):
         pass
+        
+    def test_get_mbeds(self):
+        
+        m = MbedLsToolsWin7()
+        
+        func_type = type(MbedLsToolsWin7.get_mbed_devices)
+        m.get_mbed_devices = func_type(get_mbed_devices_new, m, MbedLsToolsWin7)
+
+        mbeds = m.get_mbeds()
+        
+        self.assertIsNotNone(mbeds)
+        self.assertEqual(1, len(mbeds))
+        
+        mbed = mbeds[0]
+        
+        self.assertEqual("D:", mbed[0])
+        self.assertEqual("ATML2127031800007973", mbed[1])
+        
 
 
 if __name__ == '__main__':

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -19,12 +19,6 @@ limitations under the License.
 import unittest
 from mbed_lstools.lstools_win7 import MbedLsToolsWin7
 
-# Since we don't have mock, let's monkey-patch
-
-def get_mbed_devices_new(self):
-    return [
-        ('\\DosDevices\\D:', '_??_USBSTOR#Disk&Ven_MBED&Prod_XPRO&Rev_1.00#9&35913356&0&ATML2127031800007973&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'),
-    ]
 
 class Win7TestCase(unittest.TestCase):
     """ Basic test cases checking trivial asserts
@@ -35,24 +29,6 @@ class Win7TestCase(unittest.TestCase):
 
     def test_os_supported(self):
         pass
-        
-    def test_get_mbeds(self):
-        
-        m = MbedLsToolsWin7()
-        
-        func_type = type(MbedLsToolsWin7.get_mbed_devices)
-        m.get_mbed_devices = func_type(get_mbed_devices_new, m, MbedLsToolsWin7)
-
-        mbeds = m.get_mbeds()
-        
-        self.assertIsNotNone(mbeds)
-        self.assertEqual(1, len(mbeds))
-        
-        mbed = mbeds[0]
-        
-        self.assertEqual("D:", mbed[0])
-        self.assertEqual("ATML2127031800007973", mbed[1])
-        
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Proposed fix for: Serial number regex not allowing non-hex characters #41