### PR TITLE
Add bootloader board ID

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -42,6 +42,7 @@ class MbedLsToolsBase:
 
     # Dictionary describing mapping between manufacturers' ids and platform name.
     manufacture_ids = {
+        "0000": "Bootloader",
         "0001": "LPC2368",
         "0002": "LPC2368",
         "0003": "LPC2368",


### PR DESCRIPTION
Add the board ID "0000" for bootloader.  This allows boards in this
mode to be seen properly on Linux.