### PR TITLE
Retargeting 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # mbed-ls related files
 .mbedls-mock
+mbedls.json
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To install latest version use command:
 $ pip install mbed-ls --upgrade
 ```
 
-## Installation from Python sources 
+## Installation from Python sources
 
 **Prerequisites:** you need to have [Python 2.7.x](https://www.python.org/download/releases/2.7/) installed on your system.
 
@@ -60,7 +60,7 @@ Change the directory to the mbed-ls repository directory:
 $ cd mbed-ls
 ```
 
-Now you are ready to install mbed-ls. 
+Now you are ready to install mbed-ls.
 
 ```
 $ python setup.py install
@@ -104,37 +104,37 @@ Extended mbedls API example:
 >>> import mbed_lstools
 >>> m = mbed_lstools.create()
 >>> dir(m)
-['DEBUG_FLAG', 
- 'ERRORLEVEL_FLAG', 
- '__doc__', 
- '__init__', 
- '__module__', 
- '__str__', 
- 'debug', 
- 'discover_connected_mbeds', 
- 'err', 
- 'get_connected_mbeds', 
- 'get_dos_devices', 
- 'get_json_data_from_file', 
- 'get_mbed_com_port', 
- 'get_mbed_devices', 
- 'get_mbed_htm_target_id', 
- 'get_mbeds', 
- 'get_mounted_devices', 
- 'get_string', 
- 'iter_keys', 
- 'iter_keys_as_str', 
- 'iter_vals', 'list_mbeds', 
- 'list_mbeds_by_targetid', 
- 'list_mbeds_ext', 
- 'list_platforms', 
- 'list_platforms_ext', 
- 'load_mbed_description', 
- 'manufacture_ids', 
- 'os_supported', 
- 'regbin2str', 
- 'scan_html_line_for_target_id', 
- 'usb_vendor_list', 
+['DEBUG_FLAG',
+ 'ERRORLEVEL_FLAG',
+ '__doc__',
+ '__init__',
+ '__module__',
+ '__str__',
+ 'debug',
+ 'discover_connected_mbeds',
+ 'err',
+ 'get_connected_mbeds',
+ 'get_dos_devices',
+ 'get_json_data_from_file',
+ 'get_mbed_com_port',
+ 'get_mbed_devices',
+ 'get_mbed_htm_target_id',
+ 'get_mbeds',
+ 'get_mounted_devices',
+ 'get_string',
+ 'iter_keys',
+ 'iter_keys_as_str',
+ 'iter_vals', 'list_mbeds',
+ 'list_mbeds_by_targetid',
+ 'list_mbeds_ext',
+ 'list_platforms',
+ 'list_platforms_ext',
+ 'load_mbed_description',
+ 'manufacture_ids',
+ 'os_supported',
+ 'regbin2str',
+ 'scan_html_line_for_target_id',
+ 'usb_vendor_list',
  'winreg']
 >>> m.list_platforms()
 ['LPC1768', 'K64F']
@@ -307,6 +307,86 @@ $ mbedls
 You can help us improve the mbed-ls tools by - for example - committing a new OS port. You can see the list of currently supported OSs in the [Description](#description) section; if your OS isn't there, you can port it.
 
 For further study please check how Mac OS X (Darwin) was ported in [this pull request](https://github.com/ARMmbed/mbed-ls/pull/1).
+
+# Retarget mbed-ls autodetection results
+
+User can create file ```mbedls.json``` in given directory. ```mbedls.json``` file should contain JSON formatted data which will redefine mbed's parameters returned by mbed-ls. ```mbed-ls``` will automatically read ```mbedls.json``` file and alter auto-detection result.
+File should be placed in directory where we want to alter mbed-ls behavior.
+
+* Note: This feature in implicitly ON.
+* Note: This feature can be turned off with command line switch ```--skip-retarget```.
+
+## mbedls.json file properties
+* If file ```mbedls.json``` exists will be implicitly used to retarget results.
+* If file ```mbedls.json``` exists and flag ```--skip-retarget``` is set, there will be no retarget.
+* If file ```mbedls.json``` doesn't exist flag ```--skip-retarget``` has no effect.
+
+## Example of retargeting
+In this example we will replace serial port name during Freescale's K64F auto-detection:
+```
+$ mbedls
++--------------+---------------------+------------+------------+-------------------------------------------------+
+|platform_name |platform_name_unique |mount_point |serial_port |target_id                                        |
++--------------+---------------------+------------+------------+-------------------------------------------------+
+|K64F          |K64F[0]              |F:          |COM9        |0240022648cb1e77000000000000000000000000b512e3cf |
++--------------+---------------------+------------+------------+-------------------------------------------------+
+```
+
+Our device is detected on port ```COM9``` and MSD is mounted on ```F:```. We can check more details using ```--json``` switch:
+```
+$ mbedls --json
+[
+    {
+        "mount_point": "F:",
+        "platform_name": "K64F",
+        "platform_name_unique": "K64F[0]",
+        "serial_port": "COM9",
+        "target_id": "0240022648cb1e77000000000000000000000000b512e3cf",
+        "target_id_mbed_htm": "0240022648cb1e77000000000000000000000000b512e3cf",
+        "target_id_usb_id": "0240022648cb1e77000000000000000000000000b512e3cf"
+    }
+]
+```
+
+We must understand that ```mbed-ls``` stores information about mbed devices in dictionaries.
+The same information can be presented as dictionary where its keys are ```target_id``` and value is a mbed auto-detection data.
+
+```
+$ mbedls --json-by-target-id
+{
+    "0240022648cb1e77000000000000000000000000b512e3cf": {
+        "mount_point": "F:",
+        "platform_name": "K64F",
+        "platform_name_unique": "K64F[0]",
+        "serial_port": "COM9",
+        "target_id": "0240022648cb1e77000000000000000000000000b512e3cf",
+        "target_id_mbed_htm": "0240022648cb1e77000000000000000000000000b512e3cf",
+        "target_id_usb_id": "0240022648cb1e77000000000000000000000000b512e3cf"
+    }
+}
+```
+
+Let's say we want change ```serial_port```'s value to other COM port. For example we are using other serial port (e.g. while debugging) on our device as standard output.
+To do so we would have to create a new file called ```mbedls.json``` in directory where want to use this modification. File content could look like this: a JSON file where keys are ```target_id```'s and values are dictionaries with new values:
+
+```
+$ cat mbedls.ls
+{
+    "0240022648cb1e77000000000000000000000000b512e3cf" : {
+        "serial_port" : "MyComPort01"
+    }
+}
+```
+
+Now, when we issue ```mbedls``` command in this directory our auto-detection data will be replaced:
+```
+$ mbedls
++--------------+---------------------+------------+------------+-------------------------------------------------+
+|platform_name |platform_name_unique |mount_point |serial_port |target_id                                        |
++--------------+---------------------+------------+------------+-------------------------------------------------+
+|K64F          |K64F[0]              |F:          |MyComPort01 |0240022648cb1e77000000000000000000000000b512e3cf |
++--------------+---------------------+------------+------------+-------------------------------------------------+
+```
 
 # Mocking new or existing target to custom platform name
 Command line switch ```--mock``` provide simple manufacturers ID masking with new platform name.

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -179,8 +179,15 @@ class MbedLsToolsBase:
         if os.path.isfile(self.MOCK_FILE_NAME):
             if self.DEBUG_FLAG:
                 self.debug(self.mock_read.__name__, "reading mock file %s"% self.MOCK_FILE_NAME)
-            with open(self.MOCK_FILE_NAME, "r") as f:
-                return json.load(f)
+            try:
+                with open(self.MOCK_FILE_NAME, "r") as f:
+                    return json.load(f)
+            except IOError as e:
+                self.err("reading file '%s' failed: %s"% (os.path.abspath(self.MOCK_FILE_NAME),
+                    str(e)))
+            except ValueError as e:
+                self.err("reading file '%s' content failed: %s"% (os.path.abspath(self.MOCK_FILE_NAME),
+                    str(e)))
         return {}
 
     def mock_write(self, mock_ids):
@@ -189,8 +196,15 @@ class MbedLsToolsBase:
         """
         if self.DEBUG_FLAG:
             self.debug(self.mock_write.__name__, "writing %s"% self.MOCK_FILE_NAME)
-        with open(self.MOCK_FILE_NAME, "w") as f:
-            f.write(json.dumps(mock_ids, indent=4))
+        try:
+            with open(self.MOCK_FILE_NAME, "w") as f:
+                f.write(json.dumps(mock_ids, indent=4))
+        except IOError as e:
+            self.err("reading file '%s' failed: %s"% (os.path.abspath(self.MOCK_FILE_NAME),
+                str(e)))
+        except ValueError as e:
+            self.err("reading file '%s' content failed: %s"% (os.path.abspath(self.MOCK_FILE_NAME),
+                str(e)))
 
     def retarget_read(self):
         """! Load retarget data from local file
@@ -199,8 +213,15 @@ class MbedLsToolsBase:
         if os.path.isfile(self.RETARGET_FILE_NAME):
             if self.DEBUG_FLAG:
                 self.debug(self.retarget_read.__name__, "reading retarget file %s"% self.RETARGET_FILE_NAME)
-            with open(self.RETARGET_FILE_NAME, "r") as f:
-                return json.load(f)
+            try:
+                with open(self.RETARGET_FILE_NAME, "r") as f:
+                    return json.load(f)
+            except IOError as e:
+                self.err("reading file '%s' failed: %s"% (os.path.abspath(self.RETARGET_FILE_NAME),
+                    str(e)))
+            except ValueError as e:
+                self.err("reading file '%s' content failed: %s"% (os.path.abspath(self.RETARGET_FILE_NAME),
+                    str(e)))
         return {}
 
     def retarget(self):
@@ -271,12 +292,15 @@ class MbedLsToolsBase:
                 platform_names[platform_name] += 1
             # Assign normalized, unique string at the end of target name: TARGET_NAME[x] where x is an ordinal integer
             mbeds[i]['platform_name_unique'] = "%s[%d]" % (platform_name, platform_names[platform_name])
+
             # Retarget values from retarget (mbedls.json) file
             if self.retarget_data and 'target_id' in val:
                 target_id = val['target_id']
-                mbed[i].update(self.retarget_data[target_id])
-                if self.DEBUG_FLAG:
-                    self.debug(self.list_mbeds_ext.__name__, ("retargeting", target_id, mbed[i]))
+                if target_id in self.retarget_data:
+                    mbeds[i].update(self.retarget_data[target_id])
+                    if self.DEBUG_FLAG:
+                        self.debug(self.list_mbeds_ext.__name__, ("retargeting", target_id, mbed[i]))
+
             if self.DEBUG_FLAG:
                 self.debug(self.list_mbeds_ext.__name__, (mbeds[i]['platform_name_unique'], val['target_id']))
         return mbeds

--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -39,9 +39,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
 
     def list_mbeds(self):
         """! Returns detailed list of connected mbeds
-
             @return Returns list of structures with detailed info about each mbed
-
             @details Function returns list of dictionaries with mbed attributes such as mount point, TargetID name etc.
         """
         self.ERRORLEVEL_FLAG = 0
@@ -64,9 +62,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
 
     def discover_connected_mbeds(self, defs={}):
         """! Function produces list of mbeds with additional information and bind mbed with correct TargetID
-
             @return Returns [(<mbed_mount_point>, <mbed_id>, <com port>, <board model>), ..]
-
             @details Notice: this function is permissive: adds new elements in-places when and if found
         """
         mbeds = [(m[0], m[1], None, None) for m in self.get_connected_mbeds()]
@@ -85,11 +81,8 @@ class MbedLsToolsWin7(MbedLsToolsBase):
 
     def get_mbed_com_port(self, tid):
         """! Function checks mbed serial port in Windows registry entries
-
         @param tid TargetID
-
         @return Returns None if port is not found. In normal circumstances it should never return None
-
         @details This goes through a whole new loop, but this assures that even if serial port (COM)
                  is not detected, we still get the rest of info like mount point etc.
         """
@@ -139,18 +132,14 @@ class MbedLsToolsWin7(MbedLsToolsBase):
 
     def get_connected_mbeds(self):
         """! Function  return mbeds with existing mount point
-
         @return Returns [(<mbed_mount_point>, <mbed_id>), ..]
-
         @details Helper function
         """
         return [m for m in self.get_mbeds() if os.path.exists(m[0])]
 
     def get_mbeds(self):
         """! Function filters devices' mount points for valid TargetID
-
         @return Returns [(<mbed_mount_point>, <mbed_id>), ..]
-
         @details TargetID should be a hex string with 10-48 chars
         """
         mbeds = []
@@ -166,28 +155,26 @@ class MbedLsToolsWin7(MbedLsToolsBase):
     # =============================== Registry ====================================
 
     def iter_keys_as_str(self, key):
-        """ Iterate over subkeys of a key returning subkey as string
+        """! Iterate over subkeys of a key returning subkey as string
         """
         for i in range(self.winreg.QueryInfoKey(key)[0]):
             yield self.winreg.EnumKey(key, i)
 
     def iter_keys(self, key):
-        """ Iterate over subkeys of a key
+        """! Iterate over subkeys of a key
         """
         for i in range(self.winreg.QueryInfoKey(key)[0]):
             yield self.winreg.OpenKey(key, self.winreg.EnumKey(key, i))
 
     def iter_vals(self, key):
-        """ Iterate over values of a key
+        """! Iterate over values of a key
         """
         for i in range(self.winreg.QueryInfoKey(key)[1]):
             yield self.winreg.EnumValue(key, i)
 
     def get_mbed_devices(self):
         """! Get MBED devices (connected or not)
-
         @return List of devices
-
         @details Note: We will detect also non-standard MBED devices mentioned on 'usb_vendor_list' list.
                  This will help to detect boards like EFM boards.
         """
@@ -201,18 +188,18 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         return result
 
     def get_dos_devices(self):
-        """ Get DOS devices (connected or not)
+        """! Get DOS devices (connected or not)
         """
         ddevs = [dev for dev in self.get_mounted_devices() if 'DosDevices' in dev[0]]
         return [(d[0], self.regbin2str(d[1])) for d in ddevs]
 
     def get_mounted_devices(self):
-        """ Get all mounted devices (connected or not)
+        """! Get all mounted devices (connected or not)
         """
         mounts = self.winreg.OpenKey(self.winreg.HKEY_LOCAL_MACHINE, 'SYSTEM\MountedDevices')
         return [val for val in self.iter_vals(mounts)]
 
     def regbin2str(self, regbin):
-        """ Decode registry binary to readable string
+        """! Decode registry binary to readable string
         """
         return filter(lambda ch: ch in string.printable, regbin)

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -157,6 +157,9 @@ def mbedls_main():
 
     mbeds.DEBUG_FLAG = opts.debug
 
+    if not opts.skip_retarget:
+        mbeds.retarget()
+
     if opts.mock_platform:
         if opts.mock_platform == '*':
             if opts.json:

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -119,6 +119,12 @@ def cmd_parser_setup():
                       action="store_true",
                       help='JSON formatted dictionary of platforms count')
 
+    parser.add_option('', '--skip-retarget',
+                      dest='skip_retarget',
+                      default=False,
+                      action="store_true",
+                      help='Ignores file ./mbedls.json with retarget data')
+
     parser.add_option('-d', '--debug',
                       dest='debug',
                       default=False,


### PR DESCRIPTION
# Description
Implementation for https://github.com/ARMmbed/mbed-ls/issues/48.

User can add file ```mbedls.json``` with JSON data which will redefine mbed's parameters returned by mbed-ls.
For example user can manually add missing COM port or change port name.

## Properties
* If file ```mbedls.json``` exists will be implicitly used to retarget results.
* If file ```mbedls.json``` exists and flag ```--skip-retarget``` is set, there will be no retarget.
* If file ```mbedls.json``` doesn't exist flag ```--skip-retarget``` has no effect.

## Example of mbedls.json
```
TODO
```
