### PR TITLE
Added ID for Modtronix NZ32_SC151

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -152,6 +152,7 @@ class MbedLsToolsBase:
         "5015": "ARM_MPS2_M7",
         "5020": "HOME_GATEWAY_6LOWPAN",
         "5500": "RZ_A1H",
+        "6660": "NZ32_SC151",
         "7778": "TEENSY3_1",
         "9001": "LPC1347",
         "9002": "LPC11U24",


### PR DESCRIPTION
Added ID for Modtronix NZ32_SC151 (formally NZ32SC151). Was given ID by Sam Grove on 12/2/2016, and asked to add support for it to this repository. Please note have a current pull request on "mbedmicro/mbed" to change target name from NZ32SC151 to NZ32_SC151.