### PR TITLE
Add interface chip version to mbedls display

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -448,7 +448,7 @@ class MbedLsToolsBase:
         @details Note: This function should be improved to scan variety of boards' mbed.htm files
         """
         result = None
-        for line in self.get_mbed_htm(mount_point):
+        for line in self.get_mbed_htm_lines(mount_point):
             target_id = self.scan_html_line_for_target_id(line)
             if target_id:
                 return target_id

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -304,19 +304,20 @@ class MbedLsToolsBase:
                     if self.DEBUG_FLAG:
                         self.debug(self.list_mbeds_ext.__name__, ("retargeting", target_id, mbeds[i]))
 
-            # Add meta data to mbed structure
-            mbeds[i]['meta'] = {}
-
+            # Add interface chip meta data to mbed structure
             details_txt = self.get_details_txt(val['mount_point'])
             if details_txt:
-                mbeds[i]['meta']['DETAILS.TXT'] = details_txt
-                mbeds[i]['fw_version'] = details_txt.get('Version', 'unknown')
+                for field in details_txt:
+                    field_name = 'fw_' + field.lower().replace(' ', '_')
+                    if field_name not in mbeds[i]:
+                        mbeds[i][field_name] = details_txt[field]
 
             mbed_htm = self.get_mbed_htm(val['mount_point'])
             if mbed_htm:
-                mbeds[i]['meta']['mbed.htm'] = mbed_htm
-                if 'fw_version' not in mbeds[i]:
-                    mbeds[i]['fw_version'] = mbed_htm.get('Version', 'unknown')
+                for field in mbed_htm:
+                    field_name = 'fw_' + field.lower().replace(' ', '_')
+                    if field_name not in mbeds[i]:
+                        mbeds[i][field_name] = mbed_htm[field]
 
             if self.DEBUG_FLAG:
                 self.debug(self.list_mbeds_ext.__name__, (mbeds[i]['platform_name_unique'], val['target_id']))
@@ -408,7 +409,6 @@ class MbedLsToolsBase:
             """
             columns = ['platform_name', 'platform_name_unique', 'mount_point', 'serial_port', 'target_id', 'fw_version']
             pt = PrettyTable(columns)
-            pt.padding_width = 1
             for col in columns:
                 pt.align[col] = 'l'
 

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -393,7 +393,7 @@ class MbedLsToolsBase:
         from prettytable import PLAIN_COLUMNS
         result = ''
         mbeds = self.list_mbeds_ext()
-        if mbeds is not None:
+        if mbeds:
             """ ['platform_name', 'mount_point', 'serial_port', 'target_id'] - columns generated from USB auto-detection
                 ['platform_name_unique', ...] - columns generated outside detection subsystem (OS dependent detection)
             """
@@ -406,7 +406,7 @@ class MbedLsToolsBase:
             for mbed in mbeds:
                 row = []
                 for col in columns:
-                    row.append(mbed[col] if col in mbed and mbed[col] is not None else 'unknown')
+                    row.append(mbed[col] if col in mbed and mbed[col] else 'unknown')
                 pt.add_row(row)
             pt.set_style(PLAIN_COLUMNS)
             result = pt.get_string(border=border, header=header, padding_width=padding_width, sortby=sortby)
@@ -445,10 +445,9 @@ class MbedLsToolsBase:
                 mbed_htm_path = os.path.join(mount_point, mount_point_file)
                 try:
                     with open(mbed_htm_path, 'r') as f:
-                        fline = f.readlines()
-                        for line in fline:
+                        for line in f.readlines():
                             target_id = self.scan_html_line_for_target_id(line)
-                            if target_id is not None:
+                            if target_id:
                                 return target_id
                 except IOError:
                     if self.DEBUG_FLAG:
@@ -484,7 +483,7 @@ class MbedLsToolsBase:
         """
         # Detecting modern mbed.htm file format
         m = re.search('\?code=([a-fA-F0-9]+)', line)
-        if m is not None:
+        if m:
             result = m.groups()[0]
             if self.DEBUG_FLAG:
                 self.debug(self.scan_html_line_for_target_id.__name__, line.strip())
@@ -494,7 +493,7 @@ class MbedLsToolsBase:
         # Last resort, we can try to see if old mbed.htm format is there
         else:
             m = re.search('\?auth=([a-fA-F0-9]+)', line)
-            if m is not None:
+            if m:
                 result = m.groups()[0]
                 if self.DEBUG_FLAG:
                     self.debug(self.scan_html_line_for_target_id.__name__, line.strip())

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -391,7 +391,7 @@ class MbedLsToolsBase:
         """
         return self.get_string()
 
-    def get_string(self, border=False, header=True, padding_width=0, sortby='platform_name'):
+    def get_string(self, border=False, header=True, padding_width=1, sortby='platform_name'):
         """! Printing with some sql table like decorators
         @param border Table border visibility
         @param header Table header visibility
@@ -400,7 +400,6 @@ class MbedLsToolsBase:
         @return Returns string which can be printed on console
         """
         from prettytable import PrettyTable
-        from prettytable import PLAIN_COLUMNS
         result = ''
         mbeds = self.list_mbeds_ext()
         if mbeds:
@@ -417,7 +416,6 @@ class MbedLsToolsBase:
                 for col in columns:
                     row.append(mbed[col] if col in mbed and mbed[col] else 'unknown')
                 pt.add_row(row)
-            pt.set_style(PLAIN_COLUMNS)
             result = pt.get_string(border=border, header=header, padding_width=padding_width, sortby=sortby)
         return result
 

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -308,14 +308,14 @@ class MbedLsToolsBase:
             details_txt = self.get_details_txt(val['mount_point'])
             if details_txt:
                 for field in details_txt:
-                    field_name = 'fw_' + field.lower().replace(' ', '_')
+                    field_name = 'daplink_' + field.lower().replace(' ', '_')
                     if field_name not in mbeds[i]:
                         mbeds[i][field_name] = details_txt[field]
 
             mbed_htm = self.get_mbed_htm(val['mount_point'])
             if mbed_htm:
                 for field in mbed_htm:
-                    field_name = 'fw_' + field.lower().replace(' ', '_')
+                    field_name = 'daplink_' + field.lower().replace(' ', '_')
                     if field_name not in mbeds[i]:
                         mbeds[i][field_name] = mbed_htm[field]
 
@@ -406,7 +406,7 @@ class MbedLsToolsBase:
             """ ['platform_name', 'mount_point', 'serial_port', 'target_id'] - columns generated from USB auto-detection
                 ['platform_name_unique', ...] - columns generated outside detection subsystem (OS dependent detection)
             """
-            columns = ['platform_name', 'platform_name_unique', 'mount_point', 'serial_port', 'target_id', 'fw_version']
+            columns = ['platform_name', 'platform_name_unique', 'mount_point', 'serial_port', 'target_id', 'daplink_version']
             pt = PrettyTable(columns)
             for col in columns:
                 pt.align[col] = 'l'


### PR DESCRIPTION
Changes:
* Add ```fw_version``` column to mbedls informing about interface chip version (Data is read from ```DETAILS.TXT``` of ```mbed.htm``` for older interface chip versions.
* Add ```fw_version``` to mbedls human readable output:
* Add ```meta``` data to mbedls JSON output with ```DETAILS.TXT``` or ```mbed.htm``` information about interface chip version and/or build date-time.

# fw_version column example
```
$ mbedls
```
```
+--------------+---------------------+------------+------------+-------------------------------------------------+-----------+
|platform_name |platform_name_unique |mount_point |serial_port |target_id                                        |fw_version |
+--------------+---------------------+------------+------------+-------------------------------------------------+-----------+
|FRDM_K64F     |FRDM_K64F[0]         |E:          |COM188      |02400226d94b0e770000000000000000000000002492f3cf |0226       |
|NRF51822      |NRF51822[0]          |F:          |COM21       |107002001FE6E019E2190F91                         |0200       |
+--------------+---------------------+------------+------------+-------------------------------------------------+-----------+
```

# meta data example
```
$ mbedls --json
```
```json
[
    {
        "fw_version": "0226",
        "meta": {
            "DETAILS.TXT": {
                "Build": "Aug 24 2015 17:06:30",
                "Git Commit SHA": "27a236b9fe39c674a703c5c89655fbd26b8e27e1",
                "Git Local mods": "Yes",
                "Version": "0226"
            },
            "mbed.htm": {
                "url": "http://mbed.org/device/?code=02400226d94b0e770000000000000000000000002492f3cf"
            }
        },
        "mount_point": "E:",
        "platform_name": "FRDM_K64F",
        "platform_name_unique": "FRDM_K64F[0]",
        "serial_port": "COM188",
        "target_id": "02400226d94b0e770000000000000000000000002492f3cf",
        "target_id_mbed_htm": null,
        "target_id_usb_id": "02400226d94b0e770000000000000000000000002492f3cf"
    },
    {
        "fw_version": "0200",
        "meta": {
            "mbed.htm": {
                "Build": "Mar 26 2014 13:22:20",
                "Version": "0200",
                "url": "http://mbed.org/device/?code=107002001FE6E019E2190F91"
            }
        },
        "mount_point": "F:",
        "platform_name": "NRF51822",
        "platform_name_unique": "NRF51822[0]",
        "serial_port": "COM21",
        "target_id": "107002001FE6E019E2190F91",
        "target_id_mbed_htm": null,
        "target_id_usb_id": "107002001FE6E019E2190F91"
    }
]
```
