### PR TITLE
Add support for DETAILS.TXT and mbed.htm for DAPlink >=0240

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -496,21 +496,46 @@ class MbedLsToolsBase:
             Build:   Aug 24 2015 17:06:30
             Git Commit SHA: 27a236b9fe39c674a703c5c89655fbd26b8e27e1
             Git Local mods: Yes
+
+            or:
+
+            # DAPLink Firmware - see https://mbed.com/daplink
+            Unique ID: 0240000029164e45002f0012706e0006f301000097969900
+            HIF ID: 97969900
+            Auto Reset: 0
+            Automation allowed: 0
+            Daplink Mode: Interface
+            Interface Version: 0240
+            Git SHA: c765cbb590f57598756683254ca38b211693ae5e
+            Local Mods: 0
+            USB Interfaces: MSD, CDC, HID
+            Interface CRC: 0x26764ebf
         """
         result = {}
         path_to_details_txt = os.path.join(mount_point, self.DETAILS_TXT_NAME)
         if os.path.exists(path_to_details_txt):
             try:
                 with open(path_to_details_txt, 'r') as f:
-                    for line in f.readlines():
-                        line_split = line.split(':')
-                        if line_split:
-                            idx = line.find(':')
-                            result[line_split[0]] = line[idx+1:].strip()
+                    result = self.parse_details_txt(f.readlines())
             except IOError:
                 if self.DEBUG_FLAG:
                     self.debug(self.get_mbed_fw_version.get_details_txt.__name__, ('Failed to open file', path_to_details_txt))
         return result if result else None
+
+    def parse_details_txt(self, lines):
+        result = {}
+        for line in lines:
+            if not line.startswith('#'):
+                # Lines starting with '#' are comments
+                line_split = line.split(':')
+                if line_split:
+                    idx = line.find(':')
+                    result[line_split[0]] = line[idx+1:].strip()
+
+        # Allign with new DAPlink DETAILS.TXT format
+        if 'Interface Version' in result:
+            result['Version'] = result['Interface Version']
+        return result
 
     def scan_html_line_for_target_id(self, line):
         """! Scan if given line contains target id encoded in URL.

--- a/test/details_txt.py
+++ b/test/details_txt.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import os
+import errno
+import logging
+
+from mbed_lstools.main import create
+
+
+
+class ParseMbedHTMTestCase(unittest.TestCase):
+    """ Unit tests checking HTML parsing code for 'mbed.htm' files
+    """
+
+    details_txt_0226 = """Version: 0226
+Build:   Aug 24 2015 17:06:30
+Git Commit SHA: 27a236b9fe39c674a703c5c89655fbd26b8e27e1
+Git Local mods: Yes
+"""
+
+    details_txt_0240 = """# DAPLink Firmware - see https://mbed.com/daplink
+Unique ID: 0240000029164e45002f0012706e0006f301000097969900
+HIF ID: 97969900
+Auto Reset: 0
+Automation allowed: 0
+Daplink Mode: Interface
+Interface Version: 0240
+Git SHA: c765cbb590f57598756683254ca38b211693ae5e
+Local Mods: 0
+USB Interfaces: MSD, CDC, HID
+Interface CRC: 0x26764ebf
+"""
+
+    def setUp(self):
+        self.mbeds = create()
+
+    def tearDown(self):
+        pass
+
+    def test_simplified_daplink_txt_content(self):
+        # Fetch lines from DETAILS.TXT
+        lines = self.details_txt_0226.splitlines()
+        self.assertEqual(4, len(lines))
+
+        # Check parsing content
+        result = self.mbeds.parse_details_txt(lines)
+        self.assertEqual(4, len(result))
+        self.assertIn('Version', result)
+        self.assertIn('Build', result)
+        self.assertIn('Git Commit SHA', result)
+        self.assertIn('Git Local mods', result)
+
+        # Check for daplink_version
+        self.assertEqual(result['Version'], "0226")
+
+    def test_extended_daplink_txt_content(self):
+        # Fetch lines from DETAILS.TXT
+        lines = self.details_txt_0240.splitlines()
+        self.assertEqual(11, len(lines))
+
+        # Check parsing content
+        result = self.mbeds.parse_details_txt(lines)
+        self.assertEqual(11, len(result))   # 12th would be comment
+        self.assertIn('Unique ID', result)
+        self.assertIn('HIF ID', result)
+        self.assertIn('Auto Reset', result)
+        self.assertIn('Automation allowed', result)
+        self.assertIn('Daplink Mode', result)
+        self.assertIn('Interface Version', result)
+        self.assertIn('Git SHA', result)
+        self.assertIn('Local Mods', result)
+        self.assertIn('USB Interfaces', result)
+        self.assertIn('Interface CRC', result)
+
+        # Check if we parsed comment line:
+        # "# DAPLink Firmware - see https://mbed.com/daplink"
+        for key in result:
+            # Check if we parsed comment
+            self.assertFalse(key.startswith('#'))
+            # Check if we parsed
+            self.assertFalse('https://mbed.com/daplink' in result[key])
+
+        # Check for daplink_version
+        # DAPlink <240 compatibility
+        self.assertEqual(result['Interface Version'], "0240")
+        self.assertEqual(result['Version'], "0240")
+
+    def test_(self):
+        pass
+
+    def test_(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/mbed_htm.py
+++ b/test/mbed_htm.py
@@ -24,14 +24,19 @@ import logging
 from mbed_lstools.main import create
 
 
-test_mbed_htm_k64f_url = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=02400203D94B0E7724B7F3CF"/>'
-test_mbed_htm_l152re_url = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=07100200656A9A955A0F0CB8"/>'
-test_mbed_htm_lpc1768_url = '<meta http-equiv="refresh" content="0; url=http://mbed.org/start?auth=101000000000000000000002F7F1869557200730298d254d3ff3509e3fe4722d&loader=11972&firmware=16457&configuration=4" />'
 
 
 class ParseMbedHTMTestCase(unittest.TestCase):
     """ Unit tests checking HTML parsing code for 'mbed.htm' files
     """
+
+    # DAPlink <0240
+    test_mbed_htm_k64f_url_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=02400203D94B0E7724B7F3CF"/>'
+    test_mbed_htm_l152re_url_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=07100200656A9A955A0F0CB8"/>'
+    test_mbed_htm_lpc1768_url_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/start?auth=101000000000000000000002F7F1869557200730298d254d3ff3509e3fe4722d&loader=11972&firmware=16457&configuration=4" />'
+
+    # DAPLink 0240
+    test_daplink_240_mbed_html_str = 'window.location.replace("https://mbed.org/device/?code=0240000029164e45002f0012706e0006f301000097969900?version=0240?target_id=0007ffffffffffff4e45315450090023");'
 
     def setUp(self):
         self.mbeds = create()
@@ -40,16 +45,20 @@ class ParseMbedHTMTestCase(unittest.TestCase):
         pass
 
     def test_mbed_htm_k64f_url(self):
-        target_id = self.mbeds.scan_html_line_for_target_id(test_mbed_htm_k64f_url)
+        target_id = self.mbeds.scan_html_line_for_target_id(self.test_mbed_htm_k64f_url_str)
         self.assertEqual('02400203D94B0E7724B7F3CF', target_id)
 
     def test_mbed_htm_l152re_url(self):
-        target_id = self.mbeds.scan_html_line_for_target_id(test_mbed_htm_l152re_url)
+        target_id = self.mbeds.scan_html_line_for_target_id(self.test_mbed_htm_l152re_url_str)
         self.assertEqual('07100200656A9A955A0F0CB8', target_id)
 
     def test_mbed_htm_lpc1768_url(self):
-        target_id = self.mbeds.scan_html_line_for_target_id(test_mbed_htm_lpc1768_url)
+        target_id = self.mbeds.scan_html_line_for_target_id(self.test_mbed_htm_lpc1768_url_str)
         self.assertEqual('101000000000000000000002F7F1869557200730298d254d3ff3509e3fe4722d', target_id)
+
+    def test_daplink_240_mbed_html(self):
+        target_id = self.mbeds.scan_html_line_for_target_id(self.test_daplink_240_mbed_html_str)
+        self.assertEqual('0240000029164e45002f0012706e0006f301000097969900', target_id)
 
     def test_(self):
         pass


### PR DESCRIPTION
This is response for [daplink version is not shown when calling mbedls](https://github.com/ARMmbed/mbed-ls/issues/53).