### PR TITLE
Catch OSError when listing files in mount point

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -487,15 +487,20 @@ class MbedLsToolsBase:
     def get_mbed_htm_lines(self, mount_point):
         result = []
         if mount_point:
-            for mount_point_file in [f for f in listdir(mount_point) if isfile(join(mount_point, f))]:
-                if mount_point_file.lower() == self.MBED_HTM_NAME:
-                    mbed_htm_path = os.path.join(mount_point, mount_point_file)
-                    try:
-                        with open(mbed_htm_path, 'r') as f:
-                            result = f.readlines()
-                    except IOError:
-                        if self.DEBUG_FLAG:
-                            self.debug(self.get_mbed_htm_target_id.__name__, ('Failed to open file', mbed_htm_path))
+            try:
+                for mount_point_file in [f for f in listdir(mount_point) if isfile(join(mount_point, f))]:
+                    if mount_point_file.lower() == self.MBED_HTM_NAME:
+                        mbed_htm_path = os.path.join(mount_point, mount_point_file)
+                        try:
+                            with open(mbed_htm_path, 'r') as f:
+                                result = f.readlines()
+                        except IOError:
+                            if self.DEBUG_FLAG:
+                                self.debug(self.get_mbed_htm_target_id.__name__, ('Failed to open file', mbed_htm_path))
+            except OSError:
+                if self.DEBUG_FLAG:
+                    self.debug(self.get_mbed_htm_target_id.__name__, ('Failed to list mount point', mount_point))
+
         return result
 
     def get_details_txt(self, mount_point):


### PR DESCRIPTION
When running multiple instances of mbed-ls (using the mbed-ls module withing singletest.py and supporting scripts), we see this stacktrace sometimes in the linux machine. This causes the test script to die.

```
Traceback (most recent call last):
File "singletest.py", line 259, in <module>
  if (singletest_in_cli_mode(single_test)):
File "/home/arm/jenkins/workspace/mbed-2-build-library/workspace_tools/test_api.py", line 1487, in singletest_in_cli_mode
  test_summary, shuffle_seed, test_summary_ext, test_suite_properties_ext, build_report, build_properties = single_test.execute()
File "/home/arm/jenkins/workspace/mbed-2-build-library/workspace_tools/test_api.py", line 609, in execute
  self.execute_thread_slice(q, target, toolchains, clean, test_ids, self.build_report, self.build_properties)
File "/home/arm/jenkins/workspace/mbed-2-build-library/workspace_tools/test_api.py", line 538, in execute_thread_slice
  handle_results = self.handle(test_spec, target, toolchain, test_loops=test_loops)
File "/home/arm/jenkins/workspace/mbed-2-build-library/workspace_tools/test_api.py", line 966, in handle
  handle_result = self.handle_mut(mut, data, target_name, toolchain_name, test_loops=test_loops)
File "/home/arm/jenkins/workspace/mbed-2-build-library/workspace_tools/test_api.py", line 846, in handle_mut
  muts_list = get_autodetected_MUTS_list(platform_name_filter=platform_name_filter)
File "/home/arm/jenkins/workspace/mbed-2-build-library/workspace_tools/test_api.py", line 1643, in get_autodetected_MUTS_list
  detect_muts_list = mbeds.list_mbeds()
File "/usr/local/lib/python2.7/dist-packages/mbed_lstools/lstools_linux_generic.py", line 105, in list_mbeds
  mbed_htm_target_id = self.get_mbed_htm_target_id(device[2]) # device[2] is a 'mount_point'
File "/usr/local/lib/python2.7/dist-packages/mbed_lstools/lstools_base.py", line 457, in get_mbed_htm_target_id
  for line in self.get_mbed_htm_lines(mount_point):
File "/usr/local/lib/python2.7/dist-packages/mbed_lstools/lstools_base.py", line 489, in get_mbed_htm_lines
  for mount_point_file in [f for f in listdir(mount_point) if isfile(join(mount_point, f))]:
OSError: [Errno 13] Permission denied: '/media/arm/DAPLINK'
```

This PR catches the OSError and allows mbedls to complete without passing the exception.