### PR TITLE
Added support for Ubuntu 15 (in generic linux port)

### DIFF
--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -30,7 +30,8 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         MbedLsToolsBase.__init__(self)
         self.os_supported.append('LinuxGeneric')
         self.hex_uuid_pattern = "usb-[0-9a-zA-Z_-]*_([0-9a-zA-Z]*)-.*"
-        self.name_link_pattern = "(usb-[0-9a-zA-Z_-]*_[0-9a-zA-Z]*-.*$)"
+        # Since Ubuntu 15 DAplink serial port device can have pci- prefix, not only usb- one
+        self.name_link_pattern = '((%s)-[0-9a-zA-Z_-]*_[0-9a-zA-Z]*-.*$)'% ('|'.join(["pci", "usb"]))
         self.mount_media_pattern = "^/[a-zA-Z0-9/]* on (/[a-zA-Z0-9/]*) "
 
         self.nlp = re.compile(self.name_link_pattern)


### PR DESCRIPTION
Changes:
* Add support for ```pci-``` prefixed DAPlin CDC devices. This fix is reposnse for https://github.com/ARMmbed/mbed-ls/pull/67.
* Add unit tests for this feature.
* Released to PyPI.

---

Example debug info from Xubuntu 15:
```
$ mbedls -d
debug @MbedLsToolsUbuntu.get_dev_by_id_cmd: ls -oA /dev/disk/by-id/
debug @MbedLsToolsUbuntu.get_dev_by_id_process: lrwxrwxrwx 1 root 9 Mar 31 02:43 ata-VMware_Virtual_SATA_CDRW_Drive_00000000000000000001 -> ../../sr0
debug @MbedLsToolsUbuntu.get_dev_by_id_process: lrwxrwxrwx 1 root 9 Mar 31 02:43 ata-VMware_Virtual_SATA_CDRW_Drive_01000000000000000001 -> ../../sr1
debug @MbedLsToolsUbuntu.get_dev_by_id_process: lrwxrwxrwx 1 root 9 Apr  6 04:40 usb-MBED_VFS_0240000033514e45001f500585d40014e981000097969900-0:0 -> ../../sdb
debug @MbedLsToolsUbuntu.get_dev_by_id_cmd: ls -oA /dev/serial/by-id/
debug @MbedLsToolsUbuntu.get_dev_by_id_process: lrwxrwxrwx 1 root 13 Apr  6 04:40 pci-ARM_DAPLink_CMSIS-DAP_0240000033514e45001f500585d40014e981000097969900-if01 -> ../../ttyACM0
debug @MbedLsToolsUbuntu.get_mounts: mount | grep vfat
debug @MbedLsToolsUbuntu.get_mounts: /dev/sdb on /media/przemek/DAPLINK type vfat (rw,nosuid,nodev,relatime,uid=1000,gid=1000,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,showexec,utf8,flush,errors=remount-ro,uhelper=udisks2)
debug @MbedLsToolsUbuntu.scan_html_line_for_target_id: window.location.replace("https://mbed.org/device/?code=0240000033514e45001f500585d40014e981000097969900?version=0241?target_id=001bffffffffffff4e45315400050003");
debug @MbedLsToolsUbuntu.scan_html_line_for_target_id: (('0240000033514e45001f500585d40014e981000097969900',), '0240000033514e45001f500585d40014e981000097969900')
debug @MbedLsToolsUbuntu.list_mbeds_ext: ('K64F[0]', '0240000033514e45001f500585d40014e981000097969900')
+---------------+----------------------+------------------------+--------------+--------------------------------------------------+-----------------+
| platform_name | platform_name_unique | mount_point            | serial_port  | target_id                                        | daplink_version |
+---------------+----------------------+------------------------+--------------+--------------------------------------------------+-----------------+
| K64F          | K64F[0]              | /media/przemek/DAPLINK | /dev/ttyACM0 | 0240000033514e45001f500585d40014e981000097969900 | 0241            |
+---------------+----------------------+------------------------+--------------+--------------------------------------------------+-----------------+
debug @MbedLsToolsUbuntu.mbed_lstools.main: Return code: 0
```