### PR TITLE
added board ID for unknown daplink implementations

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -176,6 +176,7 @@ class MbedLsToolsBase:
         "9012": "SEEED_TINY_BLE",
         "9900": "NRF51_MICROBIT",
         "FFFF": "K20 BOOTLOADER",
+        "OSHW":"Unknown DAPLink Implementation",
         "RIOT": "RIOT",
     }
 


### PR DESCRIPTION
Fix for https://github.com/ARMmbed/mbed-ls/issues/75

@bridadan 