### PR TITLE
Add command execution feature with subprocess.communicate()

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -577,6 +577,7 @@ class MbedLsToolsBase:
                 return result
         return None
 
+    @staticmethod
     def run_cli_process(cmd, shell=True):
         """! Runs command as a process and return stdout, stderr and ret code
         @param cmd Command to execute

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -576,3 +576,14 @@ class MbedLsToolsBase:
                     self.debug(self.scan_html_line_for_target_id.__name__, (m.groups(), result))
                 return result
         return None
+
+    def run_cli_process(cmd, shell=True):
+        """! Runs command as a process and return stdout, stderr and ret code
+        @param cmd Command to execute
+        @return Tuple of (stdout, stderr, returncode)
+        """
+        from subprocess import Popen, PIPE
+
+        p = Popen(cmd, shell=shell, stdout=PIPE, stderr=PIPE)
+        _stdout, _stderr = p.communicate()
+        return _stdout, _stderr, p.returncode

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -16,7 +16,6 @@ limitations under the License.
 """
 
 import re
-import subprocess
 
 from lstools_base import MbedLsToolsBase
 
@@ -127,10 +126,8 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         @return tuple(stdout lines, retcode)
         """
         cmd = 'ls -oA /dev/' + subdir + '/by-id/'
-        if self.DEBUG_FLAG:
-            self.debug(self.get_dev_by_id_cmd.__name__, cmd)
-        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        return (p.stdout.readlines(), p.wait())
+        _stdout, _, retval = self.run_cli_process(cmd)
+        return (_stdout, retval)
 
     def get_dev_by_id_process(self, lines, retval):
         """! Remove unnecessary lines from command line output
@@ -159,13 +156,14 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         """
         result = []
         cmd = 'mount | grep vfat'
+
         if self.DEBUG_FLAG:
             self.debug(self.get_mounts.__name__, cmd)
 
-        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        retval = p.wait()
+        _stdout, _, retval = self.run_cli_process(cmd)
+
         if not retval:
-            for line in p.stdout.readlines():
+            for line in _stdout.readlines():
                 line = line.rstrip()
                 result.append(line)
                 if self.DEBUG_FLAG:

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -127,7 +127,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         """
         cmd = 'ls -oA /dev/' + subdir + '/by-id/'
         _stdout, _, retval = self.run_cli_process(cmd)
-        return (_stdout, retval)
+        return (_stdout.splitlines(), retval)
 
     def get_dev_by_id_process(self, lines, retval):
         """! Remove unnecessary lines from command line output
@@ -163,7 +163,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         _stdout, _, retval = self.run_cli_process(cmd)
 
         if not retval:
-            for line in _stdout.readlines():
+            for line in _stdout.splitlines():
                 line = line.rstrip()
                 result.append(line)
                 if self.DEBUG_FLAG:


### PR DESCRIPTION
## Description

When enumerating for Ubuntu calling ```mount | grep vfat``` hangs when there are many mount points. With some mount systems like LDM we can have many mount points listed with mount command. If so previous ```Popen.wait()```solution .

When a pipe's buffer fills up (typically 4KB or so), the writing process stops until a reading process has read some of the data in question; but here you're reading nothing until the subprocess is done, hence the deadlock.

Example community discussion regarding wait() vs. communicate() use [here](http://stackoverflow.com/questions/1445627/how-can-i-find-out-why-subprocess-popen-wait-waits-forever-if-stdout-pipe).

## Changes:
* Use communicate() instead of wait() when calling process with Popen(). 
* Avoid wait forever for >4kB outputs.

## Example for wait() vs communicate()
```python
# bad code
p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
p.wait()  # May block if stdout > 4kB

# good code
p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
_stdout, _stderr = p.communicate() # Will read all data from stdout/stderr
```