### PR TITLE
Add --list switch to list all target_id -> platform_name mappings available in mbed-ls

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -187,6 +187,20 @@ class MbedLsToolsBase:
     DETAILS_TXT_NAME = 'DETAILS.TXT'
     MBED_HTM_NAME = 'mbed.htm'
 
+    def list_manufacture_ids(self):
+        from prettytable import PrettyTable
+
+        columns = ['target_id_prefix', 'platform_name']
+        pt = PrettyTable(columns)
+        for col in columns:
+            pt.align[col] = 'l'
+
+        for target_id_prefix in sorted(self.manufacture_ids.keys()):
+            platform_name = self.manufacture_ids[target_id_prefix]
+            pt.add_row([target_id_prefix, platform_name])
+
+        return pt.get_string()
+
     def mock_read(self):
         """! Load mocking data from local file
         @return Curent mocking configuration (dictionary)

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -91,6 +91,12 @@ def cmd_parser_setup():
                       action="store_true",
                       help='Parser friendly verbose mode')
 
+    parser.add_option('-l', '--list',
+                      dest='list_platforms',
+                      default=False,
+                      action="store_true",
+                      help='List all platforms and corresponding TargetID values mapped by mbed-ls')
+
     parser.add_option('-m', '--mock',
                       dest='mock_platform',
                       help='Add locally manufacturers id and platform name. Example --mock=12B4:NEW_PLATFORM')
@@ -144,7 +150,7 @@ def cmd_parser_setup():
 def mbedls_main():
     """! Function used to drive CLI (command line interface) application
 
-    @return Function exits with successcode
+    @return Function exits with success code
 
     @details Function exits back to command line with ERRORLEVEL
     """
@@ -159,6 +165,10 @@ def mbedls_main():
 
     if not opts.skip_retarget:
         mbeds.retarget()
+
+    if opts.list_platforms:
+        print mbeds.list_manufacture_ids()
+        sys.exit(0)
 
     if opts.mock_platform:
         if opts.mock_platform == '*':


### PR DESCRIPTION
## Description
```
$ mbedls --list
+------------------+----------------------+
| target_id_prefix | platform_name        |
+------------------+----------------------+
  ....
| 0183             | UBLOX_C027           |
| 0200             | KL25Z                |
| 0231             | K22F                 |
| 0240             | K64F                 |
  ....
| 9009             | ARCH_BLE             |
| 9900             | NRF51_MICROBIT       |
+------------------+----------------------+
```

Above command will let you list all platforms `mbed-ls` can detect and map its `target_id` to `platform_name`.
Note: `target_id_prefix` prefix is four characters long and determines `target_id` vendor and platform IDs.
