### PR TITLE
[Silicon Labs] Added Pearl Gecko to mbed-ls

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -144,6 +144,7 @@ class MbedLsToolsBase:
         "2020": "EFM32LG_STK3600",
         "2025": "EFM32TG_STK3300",
         "2030": "EFM32ZG_STK3200",
+        "2035": "EFM32PG_STK3401",
         "2100": "XBED_LPC1768",
         "2201": "WIZWIKI_W7500",
         "2202": "WIZWIKI_W7500ECO",


### PR DESCRIPTION
Pearl Gecko (EFM32PG) was missing from the mbed-ls board list.