### PR TITLE
Adding NUCLEO_F207ZG detection

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -101,6 +101,7 @@ class MbedLsToolsBase:
         "0816": "NUCLEO_F746ZG",
         "0820": "DISCO_L476VG",
         "0824": "LPC824",
+        "0835": "NUCLEO_F207ZG",
         "0900": "XPRO_SAMR21",
         "0905": "XPRO_SAMW25",
         "0910": "XPRO_SAML21",


### PR DESCRIPTION
```
$ mbedls -j
[
    {
        "daplink_build": "Nov 19 2015 15:23:07",
        "daplink_url": "http://mbed.org/device/?code=08350221044F69753B0BF07D",
        "daplink_version": "0221",
        "mount_point": "E:",
        "platform_name": "NUCLEO_F207ZG",
        "platform_name_unique": "NUCLEO_F207ZG[0]",
        "serial_port": "COM14",
        "target_id": "08350221044F69753B0BF07D",
        "target_id_mbed_htm": "08350221044F69753B0BF07D",
        "target_id_usb_id": "0669FF545552867067035337"
    },
]
```