### PR TITLE
Add NUCLEO_F429ZI

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -94,6 +94,7 @@ class MbedLsToolsBase:
         "0790": "NUCLEO_L031K6",
         "0791": "NUCLEO_F031K6",
         "0795": "DISCO_F429ZI",
+        "0796": "NUCLEO_F429ZI",
         "0799": "ST_PLACEHOLDER",
         "0805": "DISCO_L053C8",
         "0810": "DISCO_F334C8",


### PR DESCRIPTION
    {
        "daplink_build": "Nov  4 2015 15:25:25",
        "daplink_url": "http://mbed.org/device/?code=07960221012467663E60F1CD",
        "daplink_version": "0221",
        "mount_point": "V:",
        "platform_name": "NUCLEO_F429ZI",
        "platform_name_unique": "NUCLEO_F429ZI[0]",
        "serial_port": "COM32",
        "target_id": "07960221012467663E60F1CD",
        "target_id_mbed_htm": "07960221012467663E60F1CD",
        "target_id_usb_id": "066EFF495448785187202939"
    },