### PR TITLE
-m option enhancement for specifying mount point and serial port for unsupported devices

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -267,12 +267,23 @@ class MbedLsToolsBase:
         self.retarget_data = self.retarget_read()
         return self.retarget_data
 
-    def mock_manufacture_ids(self, mid, platform_name, oper='+', mount_point=None, serial=None):
+    def mock_manufacture_ids(self, mid, platform_name, mount_point=None, serial=None, *unwanted):
         """! Replace (or add if manufacture id doesn't exist) entry in self.manufacture_ids
         @param oper '+' add new mock / override existing entry
                     '-' remove mid from mocking entry
         @return Mocked structure (json format)
         """
+        if len(unwanted):
+            print "Unwanted arguments to mock command: %s" % " ".join(unwanted)
+            sys.exit(1)
+        oper = '+'
+        if mid[0] in ['+', '-', '!']:
+            oper = mid[0]   # Operation (character)
+            mid = mid[1:]   # We remove operation character
+
+        if len(mid) != 4:
+            print "Device identifier should be 4 characters!"
+            sys.exit(1)
         mock_ids = self.mock_read()
 
         # Operations on mocked structure

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -338,6 +338,8 @@ class MbedLsToolsBase:
                         mbed['mount_point'] = mocks[mid]['mount_point']
                     if mbed['serial_port'] is None and 'serial_port' in mocks[mid]:
                         mbed['serial_port'] = mocks[mid]['serial_port']
+                    if mbed['target_id_usb_id'] is None:
+                        mbed['target_id_usb_id'] = tid
         for i, val in enumerate(mbeds):
             platform_name = val['platform_name']
             if platform_name not in platform_names:

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -178,11 +178,23 @@ def mbedls_main():
         for token in opts.mock_platform.split(','):
             if ':' in token:
                 oper = '+' # Default
-                mid, platform_name = token.split(':')
+                attributes = token.split(':')
+                mid = None
+                platform_name = None
+                mount_point = None
+                serial = None
+                if len(attributes) == 2:
+                    mid, platform_name = attributes
+                elif len(attributes) == 4:
+                    mid, platform_name, mount_point, serial = attributes
+                    mount_point += ':'
                 if mid and mid[0] in ['+', '-']:
                     oper = mid[0]   # Operation (character)
                     mid = mid[1:]   # We remove operation character
-                mbeds.mock_manufacture_ids(mid, platform_name, oper=oper)
+                if len(mid) != 4:
+                    print "Mock Id should be 4 characters!"
+                    sys.exit(1)
+                mbeds.mock_manufacture_ids(mid, platform_name, oper=oper, mount_point=mount_point, serial=serial)
             elif token and token[0] in ['-', '!']:
                 # Operations where do not specify data after colon: --mock=-1234,-7678
                 oper = token[0]

--- a/test/listing.py
+++ b/test/listing.py
@@ -51,7 +51,9 @@ class MbedListingestCase(unittest.TestCase):
 
     def test_manufacture_ids_format(self):
         for dev in self.mbeds.manufacture_ids:
-            self.assertIs(type(dev), str)
+            # Devices are either hardcoded as str values in lstools_base.py
+            # or they are read from the mock file as unicode strings
+            self.assertIn(type(dev), (str, unicode))
             self.assertEqual(len(dev), 4)
 
     def test_list_mbeds_mandatory_fields_exist(self):


### PR DESCRIPTION
Adding mount point and serial port in mock command to enable testing on targets that are mot fully detected by mbedls. Like the ones that do not have CMSIS DAPLINK interface.

Now mocks can be created like:

```
mbedls -m 00a0 Platform1 D: COM48 , 00a0 Platform1 D: COM48
```

Delimiter ':' has been replaced by position arguments. Two new arguments are supported mount point and serial port. mocks can be repeated using ',' in between.
