### PR TITLE
[NUCLEO_L011K4] Add target

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -88,7 +88,7 @@ class MbedLsToolsBase:
         "0775": "NUCLEO_F303K8",
         "0777": "NUCLEO_F446RE",
         "0778": "NUCLEO_F446ZE",
-        "0780": "ST_PLACEHOLDER",
+        "0780": "NUCLEO_L011K4",
         "0785": "NUCLEO_F042K6",
         "0788": "DISCO_F469NI",
         "0790": "NUCLEO_L031K6",


### PR DESCRIPTION
```
> mbedls -j
[
    {
        "daplink_build": "Feb 19 2016 10:50:08",
        "daplink_url": "http://mbed.org/device/?code=07800221661662045952F4B9",
        "daplink_version": "0221",
        "mount_point": "F:",
        "platform_name": "NUCLEO_L011K4",
        "platform_name_unique": "NUCLEO_L011K4[0]",
        "serial_port": "COM16",
        "target_id": "07800221661662045952F4B9",
        "target_id_mbed_htm": "07800221661662045952F4B9",
        "target_id_usb_id": "0674FF515456707067174349"
    }
]
```