### PR TITLE
[NUCLEO_L432KC] Add target

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -84,7 +84,7 @@ class MbedLsToolsBase:
         "0755": "NUCLEO_F070RB",
         "0760": "NUCLEO_L073RZ",
         "0765": "NUCLEO_L476RG",
-        "0770": "ST_PLACEHOLDER",
+        "0770": "NUCLEO_L432KC",
         "0775": "NUCLEO_F303K8",
         "0777": "NUCLEO_F446RE",
         "0778": "NUCLEO_F446ZE",


### PR DESCRIPTION
```
> mbedls -j
[
    {
        "daplink_build": "Feb 19 2016 10:50:08",
        "daplink_url": "http://mbed.org/device/?code=077002217433696B4B77FF26",
        "daplink_version": "0221",
        "mount_point": "H:",
        "platform_name": "NUCLEO_L432KC",
        "platform_name_unique": "NUCLEO_L432KC[0]",
        "serial_port": "COM25",
        "target_id": "077002217433696B4B77FF26",
        "target_id_mbed_htm": "077002217433696B4B77FF26",
        "target_id_usb_id": "0671FF565251887067045546"
    }
]
```