### PR TITLE
Add extended support for DAPlink / mbed.htm file parsing

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -484,7 +484,7 @@ class MbedLsToolsBase:
         return result
 
     def get_mbed_htm_comment_section_ver_build(self, line):
-        """! Check for Version and Build date of interface chip firmware
+        """! Check for Version and Build date of interface chip firmware im mbed.htm file
         @return (version, build) tuple if successful, None if no info found
         """
         # <!-- Version: 0200 Build: Mar 26 2014 13:22:20 -->
@@ -499,15 +499,17 @@ class MbedLsToolsBase:
             version_str, build_str = m.groups()
             return (version_str.strip(), build_str.strip())
 
+        # <!-- Version: 0.14.3. build 471 -->
+        m = re.search(r'^<!-- Version: ([\d+\.]+)\. build (\d+) -->', line)
+        if m:
+            version_str, build_str = m.groups()
+            return (version_str.strip(), build_str.strip())
         return None
 
     def get_mbed_htm(self, mount_point):
-        """!
-        <!-- mbed Microcontroller Website and Authentication Shortcut -->
-        <!-- Version: 0200 Build: Mar 26 2014 13:22:20 -->
-        <html>
-        ...
-        </html>
+        """! Check for version, build date/timestamp, URL in mbed.htm file
+        @param mount_point Where to look for mbed.htm file
+        @return Dictoionary with additional DAPlink names
         """
         result = {}
         for line in self.get_mbed_htm_lines(mount_point):

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -483,6 +483,24 @@ class MbedLsToolsBase:
                 return target_id
         return result
 
+    def get_mbed_htm_comment_section_ver_build(self, line):
+        """! Check for Version and Build date of interface chip firmware
+        @return (version, build) tuple if successful, None if no info found
+        """
+        # <!-- Version: 0200 Build: Mar 26 2014 13:22:20 -->
+        m = re.search(r'^<!-- Version: (\d+) Build: ([\d\w: ]+) -->', line)
+        if m:
+            version_str, build_str = m.groups()
+            return (version_str.strip(), build_str.strip())
+
+        # <!-- Version: 0219 Build: Feb  2 2016 15:20:54 Git Commit SHA: 0853ba0cdeae2436c52efcba0ba76a6434c200ff Git local mods:No-->
+        m = re.search(r'^<!-- Version: (\d+) Build: ([\d\w: ]+) Git Commit SHA', line)
+        if m:
+            version_str, build_str = m.groups()
+            return (version_str.strip(), build_str.strip())
+
+        return None
+
     def get_mbed_htm(self, mount_point):
         """!
         <!-- mbed Microcontroller Website and Authentication Shortcut -->
@@ -494,11 +512,9 @@ class MbedLsToolsBase:
         result = {}
         for line in self.get_mbed_htm_lines(mount_point):
             # Check for Version and Build date of interface chip firmware
-            m = re.search(r'^<!-- Version: (\d+) Build: ([\d\w: ]+) -->', line)
-            if m:
-                version_str, build_str = m.groups()
-                result['Version'] = version_str.strip()
-                result['Build'] = build_str.strip()
+            ver_bld = self.get_mbed_htm_comment_section_ver_build(line)
+            if ver_bld:
+                result['version'], result['build'] = ver_bld
 
             # Check for mbed URL
             m = re.search(r'url=([\w\d\:/\\\?\.=-_]+)', line)

--- a/test/mbed_htm.py
+++ b/test/mbed_htm.py
@@ -35,6 +35,7 @@ class ParseMbedHTMTestCase(unittest.TestCase):
     test_mbed_htm_l152re_url_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=07100200656A9A955A0F0CB8"/>'
     test_mbed_htm_lpc1768_url_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/start?auth=101000000000000000000002F7F1869557200730298d254d3ff3509e3fe4722d&loader=11972&firmware=16457&configuration=4" />'
     test_mbed_htm_nucleo_l031k6_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=07900221461663077952F5AA"/>'
+    test_mbed_htm_nrf51_url_str = '<meta http-equiv="refresh" content="0; url=http://mbed.org/device/?code=1100021952333120353935373130313232323032AFD5DFD8"/>'
 
     # DAPLink 0240
     test_daplink_240_mbed_html_str = 'window.location.replace("https://mbed.org/device/?code=0240000029164e45002f0012706e0006f301000097969900?version=0240?target_id=0007ffffffffffff4e45315450090023");'
@@ -64,6 +65,34 @@ class ParseMbedHTMTestCase(unittest.TestCase):
     def test_daplink_240_mbed_html(self):
         target_id = self.mbeds.scan_html_line_for_target_id(self.test_daplink_240_mbed_html_str)
         self.assertEqual('0240000029164e45002f0012706e0006f301000097969900', target_id)
+
+    def test_mbed_htm_nrf51_url(self):
+        target_id = self.mbeds.scan_html_line_for_target_id(self.test_mbed_htm_nrf51_url_str)
+        self.assertEqual('1100021952333120353935373130313232323032AFD5DFD8', target_id)
+
+    def get_mbed_htm_comment_section_ver_build(self):
+        # Incorrect data
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('<!-- Version: XXXX Build: Mar 26 2014 13:22:20 -->')
+        self.assertIsNone(ver_bld)
+
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('<!-- mbed Platform Website and Authentication Shortcut -->')
+        self.assertIsNone(ver_bld)
+
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('')
+        self.assertIsNone(ver_bld)
+
+        # Correct data
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('<!-- Version: 0200 Build: Mar 26 2014 13:22:20 -->')
+        self.assertIsNotNone(ver_bld)
+        self.assertEqual(('0200', 'Mar 26 2014 13:22:20'), ver_bld)
+
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('<!-- Version: 0200 Build: Aug 27 2014 13:29:28 -->')
+        self.assertIsNotNone(ver_bld)
+        self.assertEqual(('0200', 'Aug 27 2014 13:29:28'), ver_bld)
+
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('<!-- Version: 0219 Build: Feb  2 2016 15:20:54 Git Commit SHA: 0853ba0cdeae2436c52efcba0ba76a6434c200ff Git local mods:No-->')
+        self.assertIsNotNone(ver_bld)
+        self.assertEqual(('0219', 'Feb  2 2016 15:20:54'), ver_bld)
 
     def test_(self):
         pass

--- a/test/mbed_htm.py
+++ b/test/mbed_htm.py
@@ -94,6 +94,10 @@ class ParseMbedHTMTestCase(unittest.TestCase):
         self.assertIsNotNone(ver_bld)
         self.assertEqual(('0219', 'Feb  2 2016 15:20:54'), ver_bld)
 
+        ver_bld = self.mbeds.get_mbed_htm_comment_section_ver_build('<!-- Version: 0.14.3. build 471 -->')
+        self.assertIsNotNone(ver_bld)
+        self.assertEqual(('0.14.3', '471'), ver_bld)
+
     def test_(self):
         pass
 


### PR DESCRIPTION
# Description
Platforms may have non-standard mbed.htm formats. `mbed-ls` should be able to parse most common `mbed.htm` formats and correctly present `daplink_version` field which is usually embedded inside `mbed.htm` comments.

# Few examples of different mbed.htm formats we now support
```html
<!-- mbed Microcontroller Website and Authentication Shortcut -->
<!-- Version: 0200 Build: Mar 26 2014 13:22:20 -->
<html>
</html>
```

```html
<!-- mbed Microcontroller Website and Authentication Shortcut -->
<!-- Version: 0219 Build: Feb  2 2016 15:20:54 Git Commit SHA: 0853ba0cdeae2436c52efcba0ba76a6434c200ff Git local mods:No-->
<html>
</html>
```

```html
<!-- mbed website redirect -->
<!-- Version: 0.14.3. build 471 -->
<html>
</html>
```