### PR TITLE
mbed-ls: added README.md encoding specification.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ OWNER_EMAILS = 'Przemyslaw.Wirkus@arm.com, Johan.Seferidis@arm.com, James.Crosby
 
 # Utility function to cat in a file (used for the README)
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf8").read()
 
 setup(name='mbed-ls',
       version='0.2.16',


### PR DESCRIPTION
Not all operating systems have the same default file encoding.
This commit specifies an encoding, which fixes encoding errors
when running setup.py.