### PR TITLE
Add NUCLEO_F767ZI

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -101,6 +101,7 @@ class MbedLsToolsBase:
         "0810": "DISCO_F334C8",
         "0815": "DISCO_F746NG",
         "0816": "NUCLEO_F746ZG",
+        "0818": "NUCLEO_F767ZI",
         "0820": "DISCO_L476VG",
         "0824": "LPC824",
         "0835": "NUCLEO_F207ZG",


### PR DESCRIPTION
```
{
    "daplink_build": "Feb 19 2016 10:50:08",
    "daplink_url": "http://mbed.org/device/?code=08180221053B60203A7FF905",
    "daplink_version": "0221",
    "mount_point": "F:",
    "platform_name": "NUCLEO_F767ZI",
    "platform_name_unique": "NUCLEO_F767ZI[0]",
    "serial_port": "COM20",
    "target_id": "08180221053B60203A7FF905",
    "target_id_mbed_htm": "08180221053B60203A7FF905",
    "target_id_usb_id": "066DFF485550755187192807"
}
```