### PR TITLE
Add mbed-ls version string API

### DIFF
--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -149,11 +149,16 @@ def cmd_parser_setup():
 
 def mbedls_main():
     """! Function used to drive CLI (command line interface) application
-
     @return Function exits with success code
-
     @details Function exits back to command line with ERRORLEVEL
     """
+
+    def get_mbedls_version():
+        """! Get mbed-ls Python module version string """
+        import pkg_resources  # part of setuptools
+        version = pkg_resources.require("mbed-ls")[0].version
+        return version
+
     (opts, args) = cmd_parser_setup()
     mbeds = create()
 
@@ -162,6 +167,7 @@ def mbedls_main():
         sys.exit(-1)
 
     mbeds.DEBUG_FLAG = opts.debug
+    mbeds.debug(__name__, "mbed-ls ver. " + get_mbedls_version())
 
     if not opts.skip_retarget:
         mbeds.retarget()
@@ -204,14 +210,11 @@ def mbedls_main():
         print json.dumps(mbeds.list_platforms_ext(), indent=4, sort_keys=True)
 
     elif opts.version:
-        import pkg_resources  # part of setuptools
-        version = pkg_resources.require("mbed-ls")[0].version
-        print version
+        print get_mbedls_version()
 
     else:
         print mbeds.get_string(border=not opts.simple, header=not opts.simple)
 
-    if mbeds.DEBUG_FLAG:
-        mbeds.debug(__name__, "Return code: %d" % mbeds.ERRORLEVEL_FLAG)
+    mbeds.debug(__name__, "Return code: %d" % mbeds.ERRORLEVEL_FLAG)
 
     sys.exit(mbeds.ERRORLEVEL_FLAG)


### PR DESCRIPTION
Changes:
* Add version prints in debug mode.
  * Examples: `debug @MbedLsToolsWin7.mbed_lstools.main: mbed-ls ver. 1.1.0`

Snippet:
```
$ mbedls -d
debug @MbedLsToolsWin7.mbed_lstools.main: mbed-ls ver. 1.1.0
debug @MbedLsToolsWin7.get_mbed_devices: ('\\DosDevices\\E:', '_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#0240000033514e450019500585d40008e981000097969900&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}')
debug @MbedLsToolsWin7.get_mbed_devices: ('\\DosDevices\\F:', '_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#0240000030514e45004120067d7e00311f91000097969900&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}')
debug @MbedLsToolsWin7.get_mbed_devices: ('\\DosDevices\\G:', '_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#0240000033514e450040500585d4000be981000097969900&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}')
debug @MbedLsToolsWin7.get_mbed_devices: ('\\DosDevices\\H:', '_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#0240000028634e45003350066917001f5f21000097969900&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}')
debug @MbedLsToolsWin7.get_mbed_devices: ('\\DosDevices\\I:', '_??_USBSTOR#Disk&Ven_MBED&Prod_microcontroller&Rev_1.0#0240020148981E71B566E3C9&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}')
debug @MbedLsToolsWin7.get_mbed_devices: ('\\DosDevices\\J:', '_??_USBSTOR#Disk&Ven_MBED&Prod_microcontroller&Rev_1.0#024002261e031e6a000000000000000000000000e3dae3d2&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}')
debug @MbedLsToolsWin7.get_mbeds: ('E:', '0240000033514e450019500585d40008e981000097969900')
debug @MbedLsToolsWin7.get_mbeds: ('F:', '0240000030514e45004120067d7e00311f91000097969900')
debug @MbedLsToolsWin7.get_mbeds: ('G:', '0240000033514e450040500585d4000be981000097969900')
debug @MbedLsToolsWin7.get_mbeds: ('H:', '0240000028634e45003350066917001f5f21000097969900')
debug @MbedLsToolsWin7.get_mbeds: ('I:', '0240020148981E71B566E3C9')
debug @MbedLsToolsWin7.get_mbeds: ('J:', '024002261e031e6a000000000000000000000000e3dae3d2')
debug @MbedLsToolsWin7.scan_html_line_for_target_id: window.location.replace("https://mbed.org/device/?code=0240000033514e450019500585d40008e981000097969900?version=0241?target_id=0030ffffffffffff4e45315400050019");
debug @MbedLsToolsWin7.scan_html_line_for_target_id: (('0240000033514e450019500585d40008e981000097969900',), '0240000033514e450019500585d40008e981000097969900')
debug @MbedLsToolsWin7.get_mbed_com_port: ID: 0240000033514e450019500585d40008e981000097969900
debug @MbedLsToolsWin7.get_mbed_com_port: COM219
debug @MbedLsToolsWin7.scan_html_line_for_target_id: window.location.replace("https://mbed.org/device/?code=0240000033514e450040500585d4000be981000097969900?version=0241?target_id=0020ffffffffffff4e45315400050025");
debug @MbedLsToolsWin7.scan_html_line_for_target_id: (('0240000033514e450040500585d4000be981000097969900',), '0240000033514e450040500585d4000be981000097969900')
debug @MbedLsToolsWin7.get_mbed_com_port: ID: 0240000033514e450040500585d4000be981000097969900
debug @MbedLsToolsWin7.get_mbed_com_port: COM229
debug @MbedLsToolsWin7.list_mbeds_ext: ('K64F[0]', '0240000033514e450019500585d40008e981000097969900')
debug @MbedLsToolsWin7.list_mbeds_ext: ('K64F[1]', '0240000033514e450040500585d4000be981000097969900')
+---------------+----------------------+-------------+-------------+--------------------------------------------------+-----------------+
| platform_name | platform_name_unique | mount_point | serial_port | target_id                                        | daplink_version |
+---------------+----------------------+-------------+-------------+--------------------------------------------------+-----------------+
| K64F          | K64F[0]              | E:          | COM219      | 0240000033514e450019500585d40008e981000097969900 | 0241            |
| K64F          | K64F[1]              | G:          | COM229      | 0240000033514e450040500585d4000be981000097969900 | 0241            |
+---------------+----------------------+-------------+-------------+--------------------------------------------------+-----------------+
debug @MbedLsToolsWin7.mbed_lstools.main: Return code: 0
```
