### PR TITLE
Add NUMAKER_PFM_NUC472 and NUMAKER_PFM_M453

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -149,6 +149,8 @@ class MbedLsToolsBase:
         "1236": "UBLOX_C029",
         "1300": "NUC472-NUTINY",
         "1301": "NUMBED",
+        "1302": "NUMAKER_PFM_NUC472",
+        "1303": "NUMAKER_PFM_M453",
         "1549": "LPC1549",
         "1600": "LPC4330_M4",
         "1605": "LPC4330_M4",


### PR DESCRIPTION
Add support for renamed target boards:
NUMBED_NUC472 --> NUMAKER_PFM_NUC472
NUMBED_M453 --> NUMAKER_PFM_M453