### PR TITLE
Replace lockfile context mgr usage with lock.aquire() and lock.release()

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -253,7 +253,7 @@ class MbedLsToolsBase:
 
         try:
             lock = self.mbedls_get_global_lock()
-            if lock.acquire(timeout=1):
+            if lock.acquire(timeout=0.5):
                 # This read is for backward compatibility
                 # When user already have on its system local mock-up it will work
                 # overwriting global one
@@ -290,7 +290,7 @@ class MbedLsToolsBase:
 
         try:
             lock = self.mbedls_get_global_lock()
-            if lock.acquire(timeout=1):
+            if lock.acquire(timeout=0.5):
                 ret = write_mock_file(self.MOCK_HOME_FILE_NAME, mock_ids)
                 lock.release()
                 return ret


### PR DESCRIPTION
# Description

On RP2 Linux we have a deadlock when using root account so we may want to drop mocking feature but have non-blocking mbed-ls with timeout=.5 sec on file lock acquire.

# Rationale

To catch LockTImeout exception we can't use context mgr. We need to use explicit
calls to `acquire(timeout=1)` and `release()` to catch timeout.
Timeout may occur on some Resource Managers instance.

LockFile objects support the context manager protocol used by the statement:with
statement. The timeout option is not supported when used in this fashion. While
support for timeouts could be implemented, there is no support for handling the
eventual Timeout exceptions raised by the __enter__() method, so you would have
to protect the with statement with a try statement. The resulting construct
would not be any simpler than just using a try statement in the first place.

# Example timeout
```
mbedls
error: Timeout waiting to acquire lock for /home/pi/.mbed-ls/mbedls-lock
+---------------+----------------------+-------------+--------------+--------------------------------------------------+-----------------+
| platform_name | platform_name_unique | mount_point | serial_port  | target_id                                        | daplink_version |
+---------------+----------------------+-------------+--------------+--------------------------------------------------+-----------------+
| NRF51_DK      | NRF51_DK[0]          | /mnt/MBED__ | /dev/ttyACM2 | 1100021944203120324C46383030343239303038B9C6DFD8 | 0219            |
| NRF51_DK      | NRF51_DK[1]          | /mnt/MBED_  | /dev/ttyACM1 | 1100021944203120324C46383130383131323033B9C6DFD8 | 0219            |
+---------------+----------------------+-------------+--------------+--------------------------------------------------+-----------------+
```
