### PR TITLE
Replace os.mkdir() with recursive directory creation function

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -209,7 +209,10 @@ class MbedLsToolsBase:
         @details Create '.mbed-ls' sub-directory in current user $HOME directory
         """
         if not os.path.isdir(os.path.join(self.HOME_DIR, self.MBEDLS_HOME_DIR)):
-            os.mkdir(os.path.join(self.HOME_DIR, self.MBEDLS_HOME_DIR))
+            try:
+                os.makedirs(os.path.join(self.HOME_DIR, self.MBEDLS_HOME_DIR))
+            except os.error as e:
+                self.err(str(e))
 
     def mbedls_get_mocks(self):
         """! Load existing mocking configuration from current user $HOME directory

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -168,6 +168,7 @@ def mbedls_main():
 
     mbeds.DEBUG_FLAG = opts.debug
     mbeds.debug(__name__, "mbed-ls ver. " + get_mbedls_version())
+    mbeds.debug(__name__, "host: " +  str((mbed_lstools_os_info())))
 
     # Load extra mock configuration
     mbeds.mbedls_get_mocks()


### PR DESCRIPTION
Changes:
* Like mkdir(), but makes all intermediate-level directories needed to contain the leaf directory.
* This is response for #98 
* This is fix for Cygwin bug:
```
przwir01@E104178 /usr/bin
$ mbedls
Traceback (most recent call last):
  File "C:\Python27.11\Scripts\mbedls-script.py", line 9, in <module>
    load_entry_point('mbed-ls', 'console_scripts', 'mbedls')()
  File "c:\work\pypi\mbed-ls\mbed_lstools\main.py", line 163, in mbedls_main
    mbeds = create()
  File "c:\work\pypi\mbed-ls\mbed_lstools\main.py", line 42, in create
    if mbed_os == 'Windows7': result = MbedLsToolsWin7()
  File "c:\work\pypi\mbed-ls\mbed_lstools\lstools_win7.py", line 32, in __init__
    MbedLsToolsBase.__init__(self)
  File "c:\work\pypi\mbed-ls\mbed_lstools\lstools_base.py", line 39, in __init__
    self.mbedls_home_dir_init()
  File "c:\work\pypi\mbed-ls\mbed_lstools\lstools_base.py", line 212, in mbedls_                                                                               home_dir_init
    os.mkdir(os.path.join(self.HOME_DIR, self.MBEDLS_HOME_DIR))
WindowsError: [Error 3] The system cannot find the path specified: 'C:\\cygwin\\                                                                               home\\przwir01\\.mbed-ls'
```
* Add host OS debug info to debug prints

Example:
```
debug @MbedLsToolsWin7.mbed_lstools.main: host: ('nt', 'Windows', '7', '6.1.7601', 'win32')
```
