### PR TITLE
Add the VK_RZ_A1H to the list of boards

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -190,6 +190,7 @@ class MbedLsToolsBase:
         "9011": "ARCH_MAX",
         "9012": "SEEED_TINY_BLE",
         "9900": "NRF51_MICROBIT",
+        "C002": "VK_RZ_A1H",
         "FFFF": "K20 BOOTLOADER",
         "RIOT": "RIOT",
     }


### PR DESCRIPTION
Add the ID C002 for the board VK_RZ_A1H.