### PR TITLE
Disco_F769NI adding to list of boards

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -108,6 +108,7 @@ class MbedLsToolsBase:
         "0810": "DISCO_F334C8",
         "0815": "DISCO_F746NG",
         "0816": "NUCLEO_F746ZG",
+        "0817": "DISCO_F769NI",
         "0818": "NUCLEO_F767ZI",
         "0820": "DISCO_L476VG",
         "0824": "LPC824",


### PR DESCRIPTION
{
    "daplink_build": "Feb 19 2016 10:50:08",
    "daplink_url": "http://mbed.org/device/?code=08170221052460673A60F94D",
    "daplink_version": "0221",
    "mount_point": "F:",
    "platform_name": "DISCO_F769NI",
    "platform_name_unique": "DISCO_F769NI[0]",
    "serial_port": "COM30",
    "target_id": "08170221052460673A60F94D",
    "target_id_mbed_htm": "08170221052460673A60F94D",
    "target_id_usb_id": "0672FF485457725187124414"
}