### PR TITLE
Fixing issue 120. Mock platforms don't work when importing mbed_lstools

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -24,6 +24,7 @@ from os import listdir
 from os.path import isfile, join
 from lockfile import LockFailed, LockTimeout
 
+
 class MbedLsToolsBase:
     """ Base class for mbed-lstools, defines mbed-ls tools interface for mbed-enabled devices detection for various hosts
     """
@@ -37,6 +38,7 @@ class MbedLsToolsBase:
 
         # Create in HOME directory place for mbed-ls to store information
         self.mbedls_home_dir_init()
+        self.mbedls_get_mocks()
 
     # Which OSs are supported by this module
     # Note: more than one OS can be supported by mbed-lstools_* module

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -170,9 +170,6 @@ def mbedls_main():
     mbeds.debug(__name__, "mbed-ls ver. " + get_mbedls_version())
     mbeds.debug(__name__, "host: " +  str((mbed_lstools_os_info())))
 
-    # Load extra mock configuration
-    mbeds.mbedls_get_mocks()
-
     if not opts.skip_retarget:
         mbeds.retarget()
 


### PR DESCRIPTION
Fix for issue #120 
Description:
Platform mocking code was refactored into a method but method not called from the place of refactoring. Breaking the feature when ```mbed_lstools``` is imported and used. Breaking change https://github.com/ARMmbed/mbed-ls/commit/1e48f7ad8386e50cf58307bb36748ba99185bc0c#diff-62ce55aa1d58a015de03fef48a079e73L50