### PR TITLE
Removing undefined call to "get_mbed_fw_version"

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -678,8 +678,8 @@ class MbedLsToolsBase:
                 try:
                     with open(path_to_details_txt, 'r') as f:
                         result = self.parse_details_txt(f.readlines())
-                except IOError:
-                    self.debug(self.get_details_txt.__name__, ('Failed to open file', path_to_details_txt))
+                except IOError as e:
+                    self.debug(self.get_details_txt.__name__, ('Failed to open file', path_to_details_txt + '\n' + str(e)))
         return result if result else None
 
     def parse_details_txt(self, lines):

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -679,7 +679,7 @@ class MbedLsToolsBase:
                     with open(path_to_details_txt, 'r') as f:
                         result = self.parse_details_txt(f.readlines())
                 except IOError:
-                    self.debug(self.get_mbed_fw_version.get_details_txt.__name__, ('Failed to open file', path_to_details_txt))
+                    self.debug(self.get_details_txt.__name__, ('Failed to open file', path_to_details_txt))
         return result if result else None
 
     def parse_details_txt(self, lines):


### PR DESCRIPTION
There is a call to an undefined function `get_mbed_fw_version` if there is an `IOError` when attempting to open a device's `details.txt` file. This commit removes the call to this function and adds a little more debug information to assist with debugging.

cc @mazimkhan 