### PR TITLE
Add check for USB ID when getting COM port

### DIFF
--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -124,6 +124,14 @@ class MbedLsToolsWin7(MbedLsToolsBase):
                         return port
             except:
                 pass
+
+        # Check for a target USB ID from tid
+        target_usb_ids = self.get_connected_mbeds_usb_ids()
+        if tid in target_usb_ids:
+            if target_usb_ids[tid] != tid:
+                # Try again with the target USB ID
+                return self.get_mbed_com_port(target_usb_ids[tid])
+
         # If everything fails, return None
         return None
 
@@ -133,6 +141,19 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         @details Helper function
         """
         return [m for m in self.get_mbeds() if os.path.exists(m[0])]
+
+    def get_connected_mbeds_usb_ids(self):
+        """! Function  return mbeds with existing mount point's
+             target ID mapped to their target USB ID
+        @return Returns {<target_id>: <target_usb_id>, ...}
+        @details Helper function
+        """
+        connected_mbeds_ids = {}
+        for mbed in self.get_connected_mbeds():
+            htm_target_id = self.get_mbed_htm_target_id(mbed[0])
+            target_id = htm_target_id if htm_target_id else mbed[1]
+            connected_mbeds_ids[target_id] = mbed[1]
+        return connected_mbeds_ids
 
     def get_mbeds(self):
         """! Function filters devices' mount points for valid TargetID

--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -62,17 +62,15 @@ class MbedLsToolsWin7(MbedLsToolsBase):
 
     def discover_connected_mbeds(self, defs={}):
         """! Function produces list of mbeds with additional information and bind mbed with correct TargetID
-            @return Returns [(<mbed_mount_point>, <mbed_id>, <com port>, <board model>), ..]
+            @return Returns [(<mbed_mount_point>, <mbed_id>, <com port>, <board model>,
+                              <usb_target_id>, <htm_target_id>), ..]
             @details Notice: this function is permissive: adds new elements in-places when and if found
         """
         mbeds = [(m[0], m[1], None, None) for m in self.get_connected_mbeds()]
         for i in range(len(mbeds)):
             mbed = mbeds[i]
             mnt = mbed[0]
-            mbed_htm_target_id = self.get_mbed_htm_target_id(mnt)
-            # Deducing mbed-enabled TargetID based on available targetID definition DB.
-            # If TargetID from USBID is not recognized we will try to check URL in mbed.htm
-            mbed_id = mbed_htm_target_id if mbed_htm_target_id is not None else mbed[1]
+            mbed_id, mbed_htm_target_id = self.get_mbed_target_id(mnt, mbed[1])
             mbed_id_prefix = mbed_id[0:4]
             board = defs[mbed_id_prefix] if mbed_id_prefix in defs else None
             port = self.get_mbed_com_port(mbed[1])
@@ -150,8 +148,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         """
         connected_mbeds_ids = {}
         for mbed in self.get_connected_mbeds():
-            htm_target_id = self.get_mbed_htm_target_id(mbed[0])
-            target_id = htm_target_id if htm_target_id else mbed[1]
+            target_id, htm_target_id = self.get_mbed_target_id(mbed[0], mbed[1])
             connected_mbeds_ids[target_id] = mbed[1]
         return connected_mbeds_ids
 
@@ -168,6 +165,19 @@ class MbedLsToolsWin7(MbedLsToolsBase):
             mbeds += [(mountpoint, tid)]
             self.debug(self.get_mbeds.__name__, (mountpoint, tid))
         return mbeds
+
+    def get_mbed_target_id(self, mnt, target_usb_id):
+        """! Function gets the mbed target and HTM IDs
+        @param mnt mbed mount point (disk / drive letter)
+        @param target_usb_id mbed target USB ID
+        @return Function returns (<target_id>, <htm_target_id>)
+        @details Helper function
+        """
+        mbed_htm_target_id = self.get_mbed_htm_target_id(mnt)
+        # Deducing mbed-enabled TargetID based on available targetID definition DB.
+        # If TargetID from USBID is not recognized we will try to check URL in mbed.htm
+        mbed_id = mbed_htm_target_id if mbed_htm_target_id is not None else target_usb_id
+        return mbed_id, mbed_htm_target_id
 
     # =============================== Registry ====================================
 


### PR DESCRIPTION
# Changes
* Add a function to get target USB IDs for all of the connected and mounted mbed devices by their target IDs
* Add a check for a different target ID and target USB ID when getting the COM port from target ID, and then get the COM port from the target USB ID

# Fixes
* This pull request fixes #126 