### PR TITLE
Changed name for the target UBLOX_C029 to UBLOX_EVK_ODIN_W2

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -132,7 +132,7 @@ class MbedLsToolsBase:
         "1168": "LPC11U68",
         "1234": "UBLOX_C027",
         "1235": "UBLOX_C027",
-        "1236": "UBLOX_C029",
+        "1236": "UBLOX_EVK_ODIN_W2",
         "1300": "NUC472-NUTINY",
         "1301": "NUMBED",
         "1549": "LPC1549",


### PR DESCRIPTION
## Description
The official name of the old C029 target is EVK_ODIN_W2 therefore a name change is needed.
We suggest UBLOX_EVK_ODIN_W2.
Later on this target might be split into two, one module target and one development kit target.

## Status
Needs review and synchronization with mbed-os in related PR.

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/2880