### PR TITLE
Fixing tid detection in Windows

### DIFF
--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -161,7 +161,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         for mbed in self.get_mbed_devices():
             mountpoint = re.match('.*\\\\(.:)$', mbed[0]).group(1)
             # TargetID is a hex string with 10-48 chars
-            tid = re.search('[0-9A-Za-z]{10,48}', mbed[1]).group(0)
+            tid = re.search('[&#]([0-9A-Za-z]{10,48})[&#]', mbed[1]).group(1)
             mbeds += [(mountpoint, tid)]
             self.debug(self.get_mbeds.__name__, (mountpoint, tid))
         return mbeds


### PR DESCRIPTION
This fixes an issue with detecting NUCLEO boards after 316195e4d96cb47cb359618849b70c713c317a7e on Windows. It makes use of the '&' and '#' delimeter in the USB string from the registry to find the
correct tid.

Note: This is high priority as NUCLEO detection on Windows is currently broken as of v1.2.5 as detailed by #137 

FYI @adbridge 
Please take a look @mazimkhan 