### PR TITLE
Replaced use of lockfile with fasteners and optimised locking code.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,4 +51,4 @@ setup(name='mbed-ls',
       },
       install_requires=[
         "PrettyTable>=0.7.2",
-        "lockfile"])
+        "fasteners"])

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -37,13 +37,6 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(True, True)
         self.assertNotEqual(True, False)
 
-    def test_mbedls_get_global_lock(self):
-        lock = self.base.mbedls_get_global_lock()
-
-        self.assertTrue(hasattr(lock, 'acquire'))
-        self.assertTrue(hasattr(lock, 'release'))
-        self.assertTrue(hasattr(lock, 'break_lock'))
-
     def test_list_manufacture_ids(self):
         table_str = self.base.list_manufacture_ids()
 


### PR DESCRIPTION
Changes:
- Replaced ```lockfile``` with ```fasteners``` 
- Created a decorator for methods that require inter process locking.

@bridadan @adbridge Please review.