### PR TITLE
Fix retarget handling

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -74,7 +74,7 @@ class MbedLsToolsBase:
                                       MbedLsToolsBase.MBEDLS_HOME_DIR, MbedLsToolsBase.MBEDLS_GLOBAL_LOCK)
         self.mbedls_get_mocks()
         # Make sure retargeting is applied if retarget file exists
-        self.retarget()
+        self.retarget(True)
 
     # Which OSs are supported by this module
     # Note: more than one OS can be supported by mbed-lstools_* module
@@ -368,12 +368,17 @@ class MbedLsToolsBase:
                     str(e)))
         return {}
 
-    def retarget(self):
+    def retarget(self, enable=True):
         """! Enable retargeting
         @details Read data from local retarget configuration file
-        @return Retarget data structure read from configuration file
+        @param enable True  Try to read data from local retarget configuration file
+                      False Remove all retarget data read (disabling retarget functionality)
+        @return Retarget data structure read from configuration file, empty if disabled or no data found
         """
-        self.retarget_data = self.retarget_read()
+        if enable:
+            self.retarget_data = self.retarget_read()
+        else:
+            self.retarget_data = {}
         return self.retarget_data
 
     def mock_manufacture_ids(self, mid, platform_name, oper='+'):

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -73,6 +73,8 @@ class MbedLsToolsBase:
         self.lock_file = os.path.join(MbedLsToolsBase.HOME_DIR,
                                       MbedLsToolsBase.MBEDLS_HOME_DIR, MbedLsToolsBase.MBEDLS_GLOBAL_LOCK)
         self.mbedls_get_mocks()
+        # Make sure retargeting is applied if retarget file exists
+        self.retarget()
 
     # Which OSs are supported by this module
     # Note: more than one OS can be supported by mbed-lstools_* module

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -170,8 +170,8 @@ def mbedls_main():
     mbeds.debug(__name__, "mbed-ls ver. " + get_mbedls_version())
     mbeds.debug(__name__, "host: " +  str((mbed_lstools_os_info())))
 
-    if not opts.skip_retarget:
-        mbeds.retarget()
+    if opts.skip_retarget:
+        mbeds.retarget(False)
 
     if opts.list_platforms:
         print mbeds.list_manufacture_ids()


### PR DESCRIPTION
Retargeting was only loosely supported based on the code using mbed-lstools having to specifically call retarget() on the lstools to 'get' the retargeted platform.
With this fix the retarget functionality is always implemented (as long as the retarget spec file is found), leading to a much more consistent behaviour.

This is a fix for https://github.com/ARMmbed/greentea/issues/202 