### PR TITLE
Fix retarget when mbedls is imported

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -28,7 +28,7 @@ from lockfile import LockFailed, LockTimeout
 class MbedLsToolsBase:
     """ Base class for mbed-lstools, defines mbed-ls tools interface for mbed-enabled devices detection for various hosts
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         """ ctor
         """
         #extra flags
@@ -39,6 +39,9 @@ class MbedLsToolsBase:
         # Create in HOME directory place for mbed-ls to store information
         self.mbedls_home_dir_init()
         self.mbedls_get_mocks()
+        # skip retarget if specified to skip in arguments
+        if 'skip_retarget' not in kwargs or not kwargs['skip_retarget']:
+            self.retarget()
 
     # Which OSs are supported by this module
     # Note: more than one OS can be supported by mbed-lstools_* module

--- a/mbed_lstools/lstools_linux_generic.py
+++ b/mbed_lstools/lstools_linux_generic.py
@@ -23,10 +23,10 @@ from lstools_base import MbedLsToolsBase
 class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
     """ MbedLsToolsLinuxGeneric supports mbed-enabled platforms detection across Linux family
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         """! ctor
         """
-        MbedLsToolsBase.__init__(self)
+        MbedLsToolsBase.__init__(self, **kwargs)
         self.os_supported.append('LinuxGeneric')
         self.hex_uuid_pattern = "usb-[0-9a-zA-Z_-]*_([0-9a-zA-Z]*)-.*"
         # Since Ubuntu 15 DAplink serial port device can have pci- prefix, not only usb- one

--- a/mbed_lstools/lstools_ubuntu.py
+++ b/mbed_lstools/lstools_ubuntu.py
@@ -21,8 +21,8 @@ from lstools_linux_generic import MbedLsToolsLinuxGeneric
 class MbedLsToolsUbuntu(MbedLsToolsLinuxGeneric):
     """ MbedLsToolsUbuntu supports mbed-enabled platforms detection across Ubuntu OS family
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         """ ctor
         """
-        MbedLsToolsLinuxGeneric.__init__(self)
+        MbedLsToolsLinuxGeneric.__init__(self, **kwargs)
         self.os_supported.append('Ubuntu')

--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -26,10 +26,10 @@ from lstools_base import MbedLsToolsBase
 class MbedLsToolsWin7(MbedLsToolsBase):
     """ Class derived from MbedLsToolsBase ports mbed-ls functionality for Windows 7 OS
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         """ MbedLsToolsWin7 supports mbed enabled platforms detection across Windows7 OS family
         """
-        MbedLsToolsBase.__init__(self)
+        MbedLsToolsBase.__init__(self, **kwargs)
         self.os_supported.append('Windows7')
         if sys.version_info[0] < 3:
             import _winreg as winreg

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -29,9 +29,10 @@ from lstools_linux_generic import MbedLsToolsLinuxGeneric
 from lstools_darwin import MbedLsToolsDarwin
 
 
-def create():
+def create(**kwargs):
     """! Factory used to create host OS specific mbed-lstools object
 
+    :param kwargs: To pass arguments transparently to MbedLsToolsBase class.
     @return Returns MbedLsTools object or None if host OS is not supported
 
     @details Function detects host OS. Each host platform should be ported to support new host platform (OS)
@@ -39,11 +40,12 @@ def create():
     result = None
     mbed_os = mbed_os_support()
     if mbed_os is not None:
-        if mbed_os == 'Windows7': result = MbedLsToolsWin7()
-        elif mbed_os == 'Ubuntu': result = MbedLsToolsUbuntu()
-        elif mbed_os == 'LinuxGeneric': result = MbedLsToolsLinuxGeneric()
-        elif mbed_os == 'Darwin': result = MbedLsToolsDarwin()
+        if mbed_os == 'Windows7': result = MbedLsToolsWin7(**kwargs)
+        elif mbed_os == 'Ubuntu': result = MbedLsToolsUbuntu(**kwargs)
+        elif mbed_os == 'LinuxGeneric': result = MbedLsToolsLinuxGeneric(**kwargs)
+        elif mbed_os == 'Darwin': result = MbedLsToolsDarwin(**kwargs)
     return result
+
 
 def mbed_os_support():
     """! Function used to determine if host OS is supported by mbed-lstools
@@ -64,6 +66,7 @@ def mbed_os_support():
         result = 'Darwin'
     return result
 
+
 def mbed_lstools_os_info():
     """! Returns information about host OS
 
@@ -75,6 +78,7 @@ def mbed_lstools_os_info():
               platform.version(),
               sys.platform)
     return result
+
 
 def cmd_parser_setup():
     """! Configure CLI (Command Line OPtions) options
@@ -160,7 +164,7 @@ def mbedls_main():
         return version
 
     (opts, args) = cmd_parser_setup()
-    mbeds = create()
+    mbeds = create(skip_retarget=opts.skip_retarget)
 
     if mbeds is None:
         sys.stderr.write('This platform is not supported! Pull requests welcome at github.com/ARMmbed/mbed-ls\n')
@@ -169,9 +173,6 @@ def mbedls_main():
     mbeds.DEBUG_FLAG = opts.debug
     mbeds.debug(__name__, "mbed-ls ver. " + get_mbedls_version())
     mbeds.debug(__name__, "host: " +  str((mbed_lstools_os_info())))
-
-    if not opts.skip_retarget:
-        mbeds.retarget()
 
     if opts.list_platforms:
         print mbeds.list_manufacture_ids()


### PR DESCRIPTION
Rework of https://github.com/ARMmbed/mbed-ls/pull/146

Retargeting requires explicit call to ```MbedLsToolsBase.retarget()``` after importing and calling ```create()```. This isn't convenient. Hence this change moves the call to ```MbedLsToolsBase.retarget()``` in ```MbedLsToolsBase.__init__()```. Since retargeting may be disabled by command line option ```--skip-retarger``` changes are made in constructors up to ```MbedLsToolsBase.__init__()``` to allow passing of arguments from ```main()``` to the base class.

Please review and test if it meets original PR requirements @bridadan @stevew817.