### PR TITLE
Support NUMAKER_PFM_NANO130 and NUC240

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -204,6 +204,8 @@ class MbedLsToolsBase:
         "1302": "NUMAKER_PFM_NUC472",
         "1303": "NUMAKER_PFM_M453",
         "1304": "NUMAKER_PFM_M487",
+        "1306": "NUMAKER_PFM_NANO130",
+        "1307": "NUMAKER_PFM_NUC240",
         "1549": "LPC1549",
         "1600": "LPC4330_M4",
         "1605": "LPC4330_M4",


### PR DESCRIPTION
Adding 2 new boards port for mbed OS. These 2 chips are based on Coretex-M0.
I also applied these 2 platforms into mbed database through Eric Yang.