### PR TITLE
Change 5501 target name to GR_LYCHEE

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -247,7 +247,7 @@ class MbedLsToolsBase:
         "5015": "ARM_MPS2_M7",
         "5020": "HOME_GATEWAY_6LOWPAN",
         "5500": "RZ_A1H",
-        "5501": "RZ_A1LU",
+        "5501": "GR_LYCHEE",
         "6660": "NZ32_SC151",
         "7010": "BLUENINJA_CDP_TZ01B",
         "7011": "TMPM066",


### PR DESCRIPTION
Change ID 5501 name from RZ_A1LU to GR-LYCHEE.
This is request from platform vender (Renesas).