### PR TITLE
Fix unhandled exception for platforms without valid ID on OSX

### DIFF
--- a/mbed_lstools/lstools_darwin.py
+++ b/mbed_lstools/lstools_darwin.py
@@ -186,5 +186,8 @@ class MbedLsToolsDarwin(MbedLsToolsBase):
             return None
 
     def platform_name(self, target_id):
+        if target_id is None:
+            return None
+
         if target_id[:4] in self.manufacture_ids:
             return self.manufacture_ids[target_id[:4]]


### PR DESCRIPTION
Some platforms may have invalid records programmed in. For Realtek Ameba boards, which come without target ID programmed (you need to flash new firmware to fix that), mbedls was failing on unhandled exception:

```
$ mbedls -j
Traceback (most recent call last):
  File "/usr/local/bin/mbedls", line 11, in <module>
    load_entry_point('mbed-ls', 'console_scripts', 'mbedls')()
  File "/Users/barsza01/devel/mbed/code/mbed-ls/mbed_lstools/main.py", line 203, in mbedls_main
    print(json.dumps(mbeds.list_mbeds_ext(), indent=4, sort_keys=True))
  File "/Users/barsza01/devel/mbed/code/mbed-ls/mbed_lstools/lstools_base.py", line 461, in list_mbeds_ext
    mbeds = self.list_mbeds()
  File "/Users/barsza01/devel/mbed/code/mbed-ls/mbed_lstools/lstools_darwin.py", line 59, in list_mbeds
    } for v in valid_volumes
  File "/Users/barsza01/devel/mbed/code/mbed-ls/mbed_lstools/lstools_darwin.py", line 189, in platform_name
    if target_id[:4] in self.manufacture_ids:
TypeError: 'NoneType' object has no attribute '__getitem__'
```

after applying this fix:
```
$  mbedls -j
[
    {
        "daplink_url": "http://www.realtek.com.tw/", 
        "mount_point": "/Volumes/MBED 1", 
        "platform_name": null, 
        "platform_name_unique": "None[0]", 
        "serial_port": null, 
        "target_id": null, 
        "target_id_mbed_htm": null
    }
]
```

The error won't be very verbose, but at least it's no longer a crash.

CC: @theotherjimmy 