### PR TITLE
Add support for NUCLEO L496ZG

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -161,6 +161,7 @@ class MbedLsToolsBase:
         "0818": "NUCLEO_F767ZI",
         "0819": "NUCLEO_F756ZG",
         "0820": "DISCO_L476VG",
+        "0823": "NUCLEO_L496ZG",
         "0824": "LPC824",
         "0826": "NUCLEO_F412ZG",
         "0827": "NUCLEO_L486RG",


### PR DESCRIPTION
This change is requested by @jeromecoutant in https://github.com/ARMmbed/mbed-os/pull/4650#issuecomment-313325109 . It is required to add **mbed-ls** support for the newly-ported Nucleo L496ZG board.