### PR TITLE
Fix error return codes on windows

### DIFF
--- a/mbed_lstools/lstools_win7.py
+++ b/mbed_lstools/lstools_win7.py
@@ -55,7 +55,9 @@ class MbedLsToolsWin7(MbedLsToolsBase):
             d['target_id_mbed_htm'] = mbed[5] if mbed[5] else None
             mbeds += [d]
 
-            if None in mbed:
+            # Set errorlevel if mount_point, target_id,
+            # serial_port or platform_name is missing
+            if None in mbed[0:3]:
                 self.ERRORLEVEL_FLAG = -1
 
         return mbeds


### PR DESCRIPTION
Only set ERRORLEVEL_FLAG if mount_point, target_id, serial_port or platform_name is missing from an mbed device's info. This allows devices without mbed.htm to be detected without errors, as long as the relevant information is available through another mechanism, such as details.txt.

This fixes mbed-ls returning an errorcode of -1 when a microbit is attached on a windows computer.