### PR TITLE
Add support for the VBLUno51 board

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -274,6 +274,7 @@ class MbedLsToolsBase:
         "9900": "NRF51_MICROBIT",
         "C002": "VK_RZ_A1H",
         "C005": "MTM_MTCONNECT04S",
+        "C006": "VBLUNO51",
         "C030": "UBLOX_C030_U201",
         "C031": "UBLOX_C030_N211",
         "C032": "UBLOX_C030_R404M",


### PR DESCRIPTION
Add support for the VBLUno51 board

Email from Sarah Marsh (mbed):
************************************
Hi,

Here is your daplink board ID: C006
The slug: VBLUNO51

When I execute mbedls, it looks like you have used the DAPLink ID for the NRF51_DK. You need your own unique ID. We are running the tests with the NRF51_DK ID mocked as your platform, but you will need to do the following to be mbed enabled:

Please submit a PR against mbed-ls (https://github.com/ARMmbed/mbed-ls), so your board can be detected with our tools.

Please also submit a PR against DAPLink (https://github.com/mbedmicro/DAPLink), so that your board is uniquely identifiable.

Thanks,
Sarah
************************************

The VBLUno51 board was added to mbed-os 5.5.2 released
https://github.com/ARMmbed/mbed-os/pull/4629
https://github.com/ARMmbed/mbed-os/pull/4719

Signed-off-by: iotvietmember <robotden@gmail.com>