### PR TITLE
List not mounted boards on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ $ mbedls
 
 If you want to use ```mbedls``` in your toolchain, continuous integration or automation script and do not necessarily want to use the Python module ```mbed_lstools``` - this solution is for you.
 
+On some Linux systems, USB mass storage devices are not automatically mounted and do not show up when running `mbedls` by default. If you would like to include these not mounted devices in `mbedls` output, you can run mbed-ls with the `-u` option, such as `$ mbedls -u`.
+
 ## Exporting mbedls output to JSON
 
 You can export mbedls outputs to JSON format: just use the ```---json``` switch and dump your file on the screen or redirect to a file. It should help you further automate your processes.

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -67,6 +67,7 @@ class MbedLsToolsBase:
         self.DEBUG_FLAG = False     # Used to enable debug code / prints
         self.ERRORLEVEL_FLAG = 0    # Used to return success code to environment
         self.retarget_data = {}          # Used to retarget mbed-enabled platform properties
+        self.list_unmounted = False # if True, unmounted mbeds are included in output list
 
         # Create in HOME directory place for mbed-ls to store information
         self.mbedls_home_dir_init()
@@ -487,14 +488,14 @@ class MbedLsToolsBase:
                     self.debug(self.list_mbeds_ext.__name__, ("retargeting", target_id, mbeds[i]))
 
             # Add interface chip meta data to mbed structure
-            details_txt = self.get_details_txt(val['mount_point'])
+            details_txt = self.get_details_txt(val['mount_point']) if val['mount_point'] else None
             if details_txt:
                 for field in details_txt:
                     field_name = 'daplink_' + field.lower().replace(' ', '_')
                     if field_name not in mbeds[i]:
                         mbeds[i][field_name] = details_txt[field]
 
-            mbed_htm = self.get_mbed_htm(val['mount_point'])
+            mbed_htm = self.get_mbed_htm(val['mount_point']) if val['mount_point'] else None
             if mbed_htm:
                 for field in mbed_htm:
                     field_name = 'daplink_' + field.lower().replace(' ', '_')

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -135,6 +135,12 @@ def cmd_parser_setup():
                       action="store_true",
                       help='Ignores file ./mbedls.json with retarget data')
 
+    parser.add_option('-u', '--list-unmounted',
+                      dest='list_unmounted',
+                      default=False,
+                      action='store_true',
+                      help='List unmounted mbeds in addition to ones that are mounted.')
+
     parser.add_option('-d', '--debug',
                       dest='debug',
                       default=False,
@@ -164,7 +170,8 @@ def mbedls_main():
         return version
 
     (opts, args) = cmd_parser_setup()
-    mbeds = create(skip_retarget=opts.skip_retarget)
+    mbeds = create(skip_retarget=opts.skip_retarget,
+                   list_unmounted=opts.list_unmounted)
 
     if mbeds is None:
         sys.stderr.write('This platform is not supported! Pull requests welcome at github.com/ARMmbed/mbed-ls\n')


### PR DESCRIPTION
# Description

Adds the `-u`/`--list-unmounted` options to the command line of mbed-ls
that include boards that are not mounted in the mbed-ls output.

This is really only useful for systems that do not have a builtin
auto-mounter, such as a bare-bones linux install/distro.

Supersedes #56 

# TODO
 - [ ] Unit tests