### PR TITLE
Refactor mock and platform db into one class

### DIFF
--- a/mbed_lstools/lstools_darwin.py
+++ b/mbed_lstools/lstools_darwin.py
@@ -190,8 +190,4 @@ class MbedLsToolsDarwin(MbedLsToolsBase):
             return None
 
     def platform_name(self, target_id):
-        if target_id is None:
-            return None
-
-        if target_id[:4] in self.manufacture_ids:
-            return self.manufacture_ids[target_id[:4]]
+        return self.plat_db.get(target_id, None)

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -191,7 +191,8 @@ def mbedls_main():
     logger.debug("host: %s",  str((mbed_lstools_os_info())))
 
     mbeds = create(skip_retarget=opts.skip_retarget,
-                   list_unmounted=opts.list_unmounted)
+                   list_unmounted=opts.list_unmounted,
+                   force_mock=opts.mock_platform)
 
     if mbeds is None:
         logger.critical('This platform is not supported! Pull requests welcome at github.com/ARMmbed/mbed-ls')
@@ -214,12 +215,14 @@ def mbedls_main():
                 if mid and mid[0] in ['+', '-']:
                     oper = mid[0]   # Operation (character)
                     mid = mid[1:]   # We remove operation character
-                mbeds.mock_manufacture_ids(mid, platform_name, oper=oper)
+                mbeds.mock_manufacture_id(mid, platform_name, oper=oper)
             elif token and token[0] in ['-', '!']:
                 # Operations where do not specify data after colon: --mock=-1234,-7678
                 oper = token[0]
                 mid = token[1:]
-                mbeds.mock_manufacture_ids(mid, 'dummy', oper=oper)
+                mbeds.mock_manufacture_id(mid, 'dummy', oper=oper)
+            else:
+                logger.error("Could not parse mock from token: '%s'", token)
         if opts.json:
             print(json.dumps(mbeds.mock_read(), indent=4))
 

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -1,0 +1,341 @@
+"""
+mbed SDK
+Copyright (c) 2017 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Functions that manage a platform database"""
+
+import json
+import logging
+import re
+from collections import OrderedDict
+from copy import copy
+from io import open
+from os import makedirs
+from os.path import join, dirname
+from xdg import XDG_DATA_HOME
+from fasteners import InterProcessLock
+
+try:
+    unicode
+except NameError:
+    unicode = str
+
+logger = logging.getLogger("mbedls.platform_database")
+logging.basicConfig(level=logging.DEBUG)
+
+LOCAL_PLATFORM_DATABASE = join(XDG_DATA_HOME, "mbedls", "platforms.json")
+LOCAL_MOCKS_DATABASE = join(XDG_DATA_HOME, "mbedls", "mock.json")
+
+DEFAULT_PLATFORM_DB = {
+    u'0001': u'LPC2368',
+    u'0002': u'LPC2368',
+    u'0003': u'LPC2368',
+    u'0004': u'LPC2368',
+    u'0005': u'LPC2368',
+    u'0006': u'LPC2368',
+    u'0007': u'LPC2368',
+    u'0100': u'LPC2368',
+    u'0183': u'UBLOX_C027',
+    u'0200': u'KL25Z',
+    u'0201': u'KW41Z',
+    u'0210': u'KL05Z',
+    u'0214': u'HEXIWEAR',
+    u'0217': u'K82F',
+    u'0218': u'KL82Z',
+    u'0220': u'KL46Z',
+    u'0230': u'K20D50M',
+    u'0231': u'K22F',
+    u'0240': u'K64F',
+    u'0245': u'K64F',
+    u'0250': u'KW24D',
+    u'0261': u'KL27Z',
+    u'0262': u'KL43Z',
+    u'0300': u'MTS_GAMBIT',
+    u'0305': u'MTS_MDOT_F405RG',
+    u'0310': u'MTS_DRAGONFLY_F411RE',
+    u'0311': u'K66F',
+    u'0315': u'MTS_MDOT_F411RE',
+    u'0350': u'XDOT_L151CC',
+    u'0400': u'MAXWSNENV',
+    u'0405': u'MAX32600MBED',
+    u'0406': u'MAX32620MBED',
+    u'0407': u'MAX32620HSP',
+    u'0408': u'MAX32625NEXPAQ',
+    u'0409': u'MAX32630FTHR',
+    u'0415': u'MAX32625MBED',
+    u'0500': u'SPANSION_PLACEHOLDER',
+    u'0505': u'SPANSION_PLACEHOLDER',
+    u'0510': u'SPANSION_PLACEHOLDER',
+    u'0700': u'NUCLEO_F103RB',
+    u'0705': u'NUCLEO_F302R8',
+    u'0710': u'NUCLEO_L152RE',
+    u'0715': u'NUCLEO_L053R8',
+    u'0720': u'NUCLEO_F401RE',
+    u'0725': u'NUCLEO_F030R8',
+    u'0730': u'NUCLEO_F072RB',
+    u'0735': u'NUCLEO_F334R8',
+    u'0740': u'NUCLEO_F411RE',
+    u'0744': u'NUCLEO_F410RB',
+    u'0745': u'NUCLEO_F303RE',
+    u'0747': u'NUCLEO_F303ZE',
+    u'0750': u'NUCLEO_F091RC',
+    u'0755': u'NUCLEO_F070RB',
+    u'0760': u'NUCLEO_L073RZ',
+    u'0765': u'NUCLEO_L476RG',
+    u'0770': u'NUCLEO_L432KC',
+    u'0775': u'NUCLEO_F303K8',
+    u'0777': u'NUCLEO_F446RE',
+    u'0778': u'NUCLEO_F446ZE',
+    u'0780': u'NUCLEO_L011K4',
+    u'0785': u'NUCLEO_F042K6',
+    u'0788': u'DISCO_F469NI',
+    u'0790': u'NUCLEO_L031K6',
+    u'0791': u'NUCLEO_F031K6',
+    u'0795': u'DISCO_F429ZI',
+    u'0796': u'NUCLEO_F429ZI',
+    u'0797': u'NUCLEO_F439ZI',
+    u'0799': u'ST_PLACEHOLDER',
+    u'0805': u'DISCO_L053C8',
+    u'0810': u'DISCO_F334C8',
+    u'0815': u'DISCO_F746NG',
+    u'0816': u'NUCLEO_F746ZG',
+    u'0817': u'DISCO_F769NI',
+    u'0818': u'NUCLEO_F767ZI',
+    u'0819': u'NUCLEO_F756ZG',
+    u'0820': u'DISCO_L476VG',
+    u'0824': u'LPC824',
+    u'0826': u'NUCLEO_F412ZG',
+    u'0827': u'NUCLEO_L486RG',
+    u'0835': u'NUCLEO_F207ZG',
+    u'0840': u'B96B_F446VE',
+    u'0900': u'XPRO_SAMR21',
+    u'0905': u'XPRO_SAMW25',
+    u'0910': u'XPRO_SAML21',
+    u'0915': u'XPRO_SAMD21',
+    u'1000': u'LPC2368',
+    u'1001': u'LPC2368',
+    u'1010': u'LPC1768',
+    u'1017': u'HRM1017',
+    u'1018': u'SSCI824',
+    u'1019': u'TY51822R3',
+    u'1022': u'BP359B',
+    u'1034': u'LPC11U34',
+    u'1040': u'LPC11U24',
+    u'1045': u'LPC11U24',
+    u'1050': u'LPC812',
+    u'1060': u'LPC4088',
+    u'1061': u'LPC11U35_401',
+    u'1062': u'LPC4088_DM',
+    u'1070': u'NRF51822',
+    u'1075': u'NRF51822_OTA',
+    u'1080': u'OC_MBUINO',
+    u'1090': u'RBLAB_NRF51822',
+    u'1095': u'RBLAB_BLENANO',
+    u'1100': u'NRF51_DK',
+    u'1101': u'NRF52_DK',
+    u'1105': u'NRF51_DK_OTA',
+    u'1114': u'LPC1114',
+    u'1120': u'NRF51_DONGLE',
+    u'1130': u'NRF51822_SBK',
+    u'1140': u'WALLBOT_BLE',
+    u'1168': u'LPC11U68',
+    u'1200': u'NCS36510',
+    u'1234': u'UBLOX_C027',
+    u'1235': u'UBLOX_C027',
+    u'1236': u'UBLOX_EVK_ODIN_W2',
+    u'1300': u'NUC472-NUTINY',
+    u'1301': u'NUMBED',
+    u'1302': u'NUMAKER_PFM_NUC472',
+    u'1303': u'NUMAKER_PFM_M453',
+    u'1304': u'NUMAKER_PFM_M487',
+    u'1549': u'LPC1549',
+    u'1600': u'LPC4330_M4',
+    u'1605': u'LPC4330_M4',
+    u'2000': u'EFM32_G8XX_STK',
+    u'2005': u'EFM32HG_STK3400',
+    u'2010': u'EFM32WG_STK3800',
+    u'2015': u'EFM32GG_STK3700',
+    u'2020': u'EFM32LG_STK3600',
+    u'2025': u'EFM32TG_STK3300',
+    u'2030': u'EFM32ZG_STK3200',
+    u'2035': u'EFM32PG_STK3401',
+    u'2100': u'XBED_LPC1768',
+    u'2201': u'WIZWIKI_W7500',
+    u'2202': u'WIZWIKI_W7500ECO',
+    u'2203': u'WIZWIKI_W7500P',
+    u'3001': u'LPC11U24',
+    u'4000': u'LPC11U35_Y5_MBUG',
+    u'4005': u'NRF51822_Y5_MBUG',
+    u'4100': u'MOTE_L152RC',
+    u'4337': u'LPC4337',
+    u'4500': u'DELTA_DFCM_NNN40',
+    u'4501': u'DELTA_DFBM_NQ620',
+    u'4502': u'DELTA_DFCM_NNN50',
+    u'4600': u'REALTEK_RTL8195AM',
+    u'5000': u'ARM_MPS2',
+    u'5001': u'ARM_MPS2_M0',
+    u'5003': u'ARM_BEETLE_SOC',
+    u'5005': u'ARM_MPS2_M0DS',
+    u'5007': u'ARM_MPS2_M1',
+    u'5009': u'ARM_MPS2_M3',
+    u'5011': u'ARM_MPS2_M4',
+    u'5015': u'ARM_MPS2_M7',
+    u'5020': u'HOME_GATEWAY_6LOWPAN',
+    u'5500': u'RZ_A1H',
+    u'6660': u'NZ32_SC151',
+    u'7010': u'BLUENINJA_CDP_TZ01B',
+    u'7778': u'TEENSY3_1',
+    u'8001': u'UNO_91H',
+    u'9001': u'LPC1347',
+    u'9002': u'LPC11U24',
+    u'9003': u'LPC1347',
+    u'9004': u'ARCH_PRO',
+    u'9006': u'LPC11U24',
+    u'9007': u'LPC11U35_501',
+    u'9008': u'XADOW_M0',
+    u'9009': u'ARCH_BLE',
+    u'9010': u'ARCH_GPRS',
+    u'9011': u'ARCH_MAX',
+    u'9012': u'SEEED_TINY_BLE',
+    u'9900': u'NRF51_MICROBIT',
+    u'C002': u'VK_RZ_A1H',
+    u'FFFF': u'K20 BOOTLOADER',
+    u'RIOT': u'RIOT',
+}
+
+class PlatformDatabase(object):
+    """Represents a union of multiple platform database files.
+    Handles inter-process synchronization of database files.
+    """
+
+    target_id_pattern = re.compile(r'^[a-fA-F0-9]{4}$')
+
+    def __init__(self, database_files, primary_database=None):
+        """Construct a PlatformDatabase object from a series of platform database files"""
+        self._prim_db = primary_database
+        if not self._prim_db and len(database_files) == 1:
+            self._prim_db = database_files[0]
+        self._dbs = OrderedDict()
+        self._keys = set()
+        for db in database_files:
+            try:
+                new_db = json.load(open(db, encoding="utf-8"))
+                duplicates = set(self._keys).intersection(set(new_db.keys()))
+                if duplicates:
+                    logger.warning(
+                        "Duplicate platform ids found: %s,"
+                        " ignoring the definitions from %s",
+                        " ".join(duplicates), db)
+                self._dbs[db] = new_db
+                self._keys = self._keys.union(new_db.keys())
+            except IOError as exc:
+                if db is LOCAL_PLATFORM_DATABASE:
+                    logger.warning(
+                        "Could not open local platform database at %s; "
+                        "Recereating", db)
+                    try:
+                        makedirs(dirname(db))
+                    except OSError:
+                        pass
+                    with open(db, "w", encoding="utf-8") as out:
+                        out.write(unicode(json.dumps(DEFAULT_PLATFORM_DB)))
+                    new_db = copy(DEFAULT_PLATFORM_DB)
+                    self._dbs[db] = new_db
+                    self._keys = self._keys.union(new_db.keys())
+                else:
+                    if db is not self._prim_db:
+                        logger.error(
+                            "Could not open platform database %s: %s; skipping",
+                            db, str(exc))
+                    self._dbs[db] = {}
+            except ValueError as exc:
+                logger.error(
+                    "Could not parse platform database %s because %s; "
+                    "skipping", db, str(exc))
+                self._dbs[db] = {}
+
+    def items(self):
+        for db in self._dbs.values():
+            for entry in db.items():
+                yield entry
+
+    def all_ids(self):
+        return iter(self._keys)
+
+    def get(self, index, default=None):
+        """Standard lookup function. Works exactly like a dict"""
+        for db in self._dbs.values():
+            maybe_answer = db.get(index, None)
+            if maybe_answer:
+                return maybe_answer
+
+        return default
+
+    def _update_db(self):
+        if self._prim_db:
+            lock = InterProcessLock("%s.lock" % self._prim_db)
+            acquired = lock.acquire(blocking=False)
+            if not acquired:
+                logger.debug("Waiting 60 seconds for file lock")
+                acquired = lock.acquire(blocking=True, timeout=60)
+            if acquired:
+                try:
+                    with open(self._prim_db, "w", encoding="utf-8") as out:
+                        out.write(unicode(
+                            json.dumps(self._dbs[self._prim_db])))
+                    return True
+                finally:
+                    lock.release()
+            else:
+                logger.error("Could not update platform database: "
+                             "Lock acquire failed after 60 seconds")
+                return False
+        else:
+            logger.error("Can't update platform database: "
+                         "destination database is ambiguous")
+            return False
+
+    def add(self, id, platform_name, permanent=False):
+        """Add a platform to this database, optionally updating an origin
+        database
+        """
+        if self.target_id_pattern.match(id):
+            if self._prim_db:
+                self._dbs[self._prim_db][id] = platform_name
+            else:
+                next(iter(self._dbs.values()))[id] = platform_name
+            self._keys.add(id)
+            if permanent:
+                self._update_db()
+        else:
+            raise ValueError("Invald target id: %s" % id)
+
+    def remove(self, id, permanent=False):
+        """Remove a platform from this database, optionally updating an origin
+        database
+        """
+        logger.debug("Trying remove of %s", id)
+        if id is '*':
+            self._dbs[self._prim_db] = {}
+        for db in self._dbs.values():
+            if id in db:
+                logger.debug("Removing id...")
+                removed = db[id]
+                del db[id]
+                self._keys.remove(id)
+                if permanent:
+                    self._update_db()
+                return removed

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,9 @@ setup(name='mbed-ls',
         ],
       },
       install_requires=[
-        "PrettyTable>=0.7.2",
-          "fasteners"
+          "PrettyTable>=0.7.2",
+          "fasteners",
+          "xdg>=1.0"
       ],
       extras_require = {
           "colorized_logs": ["colorlog"]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ setup(name='mbed-ls',
           "fasteners",
           "xdg>=1.0"
       ],
+      tests_require = [
+          "mock>=2",
+          "pytest>=3"
+      ],
       extras_require = {
           "colorized_logs": ["colorlog"]
       }

--- a/test/listing.py
+++ b/test/listing.py
@@ -46,12 +46,8 @@ class MbedListingestCase(unittest.TestCase):
         self.assertNotEqual(None, self.mbeds.list_mbeds_ext())
         self.assertIs(type(self.mbeds.list_mbeds_ext()), list)
 
-    def test_manufacture_ids_type(self):
-        self.assertIs(type(self.mbeds.manufacture_ids), dict)
-
     def test_manufacture_ids_format(self):
-        for dev in self.mbeds.manufacture_ids:
-            self.assertIs(type(dev), str)
+        for dev in self.mbeds.plat_db.all_ids():
             self.assertEqual(len(dev), 4)
 
     def test_list_mbeds_mandatory_fields_exist(self):

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -47,128 +47,42 @@ class BasicTestCase(unittest.TestCase):
         table_str = self.base.list_manufacture_ids()
         self.assertTrue(isinstance(table_str, basestring))
 
-    def test_mock_read(self):
-        mock_data = self.base.mock_read()
-
-        self.assertIs(type(mock_data), dict)
-
-    def test_mock_read_write(self):
-        mock_data = self.base.mock_read()
-        self.assertIs(type(mock_data), dict)
-
-        ret = self.base.mock_write(mock_data)
-        self.assertTrue(ret)
-
-        mock_data_after_write = self.base.mock_read()
-        self.assertIs(type(mock_data_after_write), dict)
-
-        self.assertEqual(mock_data, mock_data_after_write)
-
-    def test_mock_read_write_custom_data(self):
-        """
-        1. Read original mock data
-        2. Write custom data
-        3. Read (custom) mock data
-        4. Write original mock data
-        """
-
-        mock_data = self.base.mock_read()
-        self.assertIs(type(mock_data), dict)
-
-        custom_mock_data = {
-            "0240": "K__F",
-            "ABCD": "SOME_PLATFORM"
-        }
-
-        ret = self.base.mock_write(custom_mock_data)
-        self.assertTrue(ret)
-
-        mock_data_after_write = self.base.mock_read()
-        self.assertIs(type(mock_data_after_write), dict)
-
-        self.assertEqual(custom_mock_data, mock_data_after_write)
-
-        ret = self.base.mock_write(mock_data)
-        self.assertTrue(ret)
-
-        mock_data_after_write = self.base.mock_read()
-        self.assertIs(type(mock_data_after_write), dict)
-
-        self.assertEqual(mock_data, mock_data_after_write)
-
-    def test_mock_manufacture_ids_default(self):
-        mock_data = self.base.mock_read()
-        self.assertIs(type(mock_data), dict)
-
-        # oper='+'
-        mock_ids = self.base.mock_manufacture_ids('TEST', 'TEST_PLATFORM_NAME')
-
-        self.assertIn('TEST', mock_ids)
-        self.assertEqual('TEST_PLATFORM_NAME', mock_ids['TEST'])
-
-        ret = self.base.mock_write(mock_data)
-        self.assertTrue(ret)
-
     def test_mock_manufacture_ids_default_multiple(self):
-        mock_data = self.base.mock_read()
-        self.assertIs(type(mock_data), dict)
-
         # oper='+'
-        for mid, platform_name in [('TEST_1', 'TEST_PLATFORM_NAME_1'),
-                                   ('TEST_2', 'TEST_PLATFORM_NAME_2'),
-                                   ('TEST_3', 'TEST_PLATFORM_NAME_3')]:
-            mock_ids = self.base.mock_manufacture_ids(mid, platform_name)
-
-            self.assertIn(mid, mock_ids)
-            self.assertEqual(platform_name, mock_ids[mid])
-
-        ret = self.base.mock_write(mock_data)
-        self.assertTrue(ret)
+        for mid, platform_name in [('0341', 'TEST_PLATFORM_NAME_1'),
+                                   ('0342', 'TEST_PLATFORM_NAME_2'),
+                                   ('0343', 'TEST_PLATFORM_NAME_3')]:
+            self.base.mock_manufacture_id(mid, platform_name)
+            self.assertEqual(platform_name, self.base.plat_db.get(mid))
 
     def test_mock_manufacture_ids_minus(self):
-        mock_data = self.base.mock_read()
-        self.assertIs(type(mock_data), dict)
-
         # oper='+'
-        for mid, platform_name in [('TEST_1', 'TEST_PLATFORM_NAME_1'),
-                                   ('TEST_2', 'TEST_PLATFORM_NAME_2'),
-                                   ('TEST_3', 'TEST_PLATFORM_NAME_3')]:
-            mock_ids = self.base.mock_manufacture_ids(mid, platform_name)
-
-            self.assertIn(mid, mock_ids)
-            self.assertEqual(platform_name, mock_ids[mid])
+        for mid, platform_name in [('0341', 'TEST_PLATFORM_NAME_1'),
+                                   ('0342', 'TEST_PLATFORM_NAME_2'),
+                                   ('0343', 'TEST_PLATFORM_NAME_3')]:
+            self.base.mock_manufacture_id(mid, platform_name)
+            self.assertEqual(platform_name, self.base.plat_db.get(mid))
 
         # oper='-'
-        mock_ids = self.base.mock_manufacture_ids('TEST_2', '', oper='-')
-        self.assertIn('TEST_1', mock_ids)
-        self.assertNotIn('TEST_2', mock_ids)
-        self.assertIn('TEST_3', mock_ids)
-
-        ret = self.base.mock_write(mock_data)
-        self.assertTrue(ret)
+        mock_ids = self.base.mock_manufacture_id('0342', '', oper='-')
+        self.assertEqual('TEST_PLATFORM_NAME_1', self.base.plat_db.get("0341"))
+        self.assertEqual(None, self.base.plat_db.get("0342"))
+        self.assertEqual('TEST_PLATFORM_NAME_3', self.base.plat_db.get("0343"))
 
     def test_mock_manufacture_ids_star(self):
-        mock_data = self.base.mock_read()
-        self.assertIs(type(mock_data), dict)
-
         # oper='+'
-        for mid, platform_name in [('TEST_1', 'TEST_PLATFORM_NAME_1'),
-                                   ('TEST_2', 'TEST_PLATFORM_NAME_2'),
-                                   ('TEST_3', 'TEST_PLATFORM_NAME_3')]:
-            mock_ids = self.base.mock_manufacture_ids(mid, platform_name)
+        for mid, platform_name in [('0341', 'TEST_PLATFORM_NAME_1'),
+                                   ('0342', 'TEST_PLATFORM_NAME_2'),
+                                   ('0343', 'TEST_PLATFORM_NAME_3')]:
+            self.base.mock_manufacture_id(mid, platform_name)
 
-            self.assertIn(mid, mock_ids)
-            self.assertEqual(platform_name, mock_ids[mid])
+            self.assertEqual(platform_name, self.base.plat_db.get(mid))
 
         # oper='-'
-        mock_ids = self.base.mock_manufacture_ids('*', '', oper='-')
-        self.assertNotIn('TEST_1', mock_ids)
-        self.assertNotIn('TEST_2', mock_ids)
-        self.assertNotIn('TEST_3', mock_ids)
-        self.assertFalse(mock_ids)
-
-        ret = self.base.mock_write(mock_data)
-        self.assertTrue(ret)
+        self.base.mock_manufacture_id('*', '', oper='-')
+        self.assertEqual(None, self.base.plat_db.get("0341"))
+        self.assertEqual(None, self.base.plat_db.get("0342"))
+        self.assertEqual(None, self.base.plat_db.get("0343"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -45,7 +45,6 @@ class BasicTestCase(unittest.TestCase):
 
     def test_list_manufacture_ids(self):
         table_str = self.base.list_manufacture_ids()
-
         self.assertTrue(isinstance(table_str, basestring))
 
     def test_mock_read(self):

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -18,6 +18,7 @@ limitations under the License.
 
 import unittest
 from mbed_lstools.lstools_linux_generic import MbedLsToolsLinuxGeneric
+from mbed_lstools.platform_database import LOCAL_PLATFORM_DATABASE
 
 
 class LinuxPortTestCase(unittest.TestCase):
@@ -59,6 +60,7 @@ class LinuxPortTestCase(unittest.TestCase):
             "0720": "NUCLEO_F401RE",    # Under test
             "0725": "NUCLEO_F030R8",
         }
+        self.linux_generic.plat_db._dbs[LOCAL_PLATFORM_DATABASE] = self.tids
 
         self.disk_list_1 = [
           "total 0",

--- a/test/platform_database.py
+++ b/test/platform_database.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import os
+import errno
+import logging
+import tempfile
+import json
+from mock import patch, MagicMock
+
+from mbed_lstools.platform_database import PlatformDatabase
+
+class EmptyPlatformDatabaseTests(unittest.TestCase):
+    """ Basic test cases with an empty database
+    """
+
+    def setUp(self):
+        self.base_db = tempfile.NamedTemporaryFile(prefix='base')
+        self.base_db.write(b'{}')
+        self.base_db.seek(0)
+        self.pdb = PlatformDatabase([self.base_db.name])
+
+    def tearDown(self):
+        pass
+
+    def test_bogus_database(self):
+        """Basic empty database test
+        """
+        self.assertEqual(list(self.pdb.items()), [])
+        self.assertEqual(list(self.pdb.all_ids()), [])
+        self.assertEqual(self.pdb.get('Also_Junk', None), None)
+
+    def test_add(self):
+        """Test that what was added can later be queried
+        """
+        self.assertEqual(self.pdb.get('4753', None), None)
+        self.pdb.add('4753', 'Test_Platform', permanent=False)
+        self.assertEqual(self.pdb.get('4753', None), 'Test_Platform')
+
+    def test_remove(self):
+        """Test that once something is removed it no longer shows up when queried
+        """
+        self.assertEqual(self.pdb.get('4753', None), None)
+        self.pdb.add('4753', 'Test_Platform', permanent=False)
+        self.assertEqual(self.pdb.get('4753', None), 'Test_Platform')
+        self.assertEqual(self.pdb.remove('4753', permanent=False), 'Test_Platform')
+        self.assertEqual(self.pdb.get('4753', None), None)
+
+    def test_bogus_add(self):
+        """Test that add requires properly formatted platform ids
+        """
+        self.assertEqual(self.pdb.get('NOTVALID', None), None)
+        with self.assertRaises(ValueError):
+            self.pdb.add('NOTVALID', 'Test_Platform', permanent=False)
+
+    def test_bogus_remove(self):
+        """Test that removing a not present platform does nothing
+        """
+        self.assertEqual(self.pdb.get('NOTVALID', None), None)
+        self.assertEqual(self.pdb.remove('NOTVALID', permanent=False), None)
+
+class OverriddenPlatformDatabaseTests(unittest.TestCase):
+    """ Test that for one database overriding another
+    """
+
+    def setUp(self):
+        self.base_db = tempfile.NamedTemporaryFile(prefix='base')
+        self.base_db.write(json.dumps(dict([('0123', 'Base_Platform')])).
+                           encode('utf-8'))
+        self.base_db.seek(0)
+        self.overriding_db = tempfile.NamedTemporaryFile(prefix='overriding')
+        self.overriding_db.write(b'{}')
+        self.overriding_db.seek(0)
+        self.pdb = PlatformDatabase([self.overriding_db.name, self.base_db.name],
+                                    primary_database=self.overriding_db.name)
+        self.base_db.seek(0)
+        self.overriding_db.seek(0)
+
+    def tearDown(self):
+        pass
+
+    def assertBaseUnchanged(self):
+        """Assert that the base database has not changed
+        """
+        self.base_db.seek(0)
+        self.assertEqual(self.base_db.read(),
+                         json.dumps(dict([('0123', 'Base_Platform')]))
+                         .encode('utf-8'))
+
+    def assertOverrideUnchanged(self):
+        """Assert that the override database has not changed
+        """
+        self.overriding_db.seek(0)
+        self.assertEqual(self.overriding_db.read(), b'{}')
+
+    def test_basline(self):
+        """Sanity check that the base database does what we expect
+        """
+        self.assertEqual(list(self.pdb.items()), [('0123', 'Base_Platform')])
+        self.assertEqual(list(self.pdb.all_ids()), ['0123'])
+
+    def test_add_non_override(self):
+        """Check that adding keys goes to the Override database
+        """
+        self.pdb.add('1234', 'Another_Platform')
+        self.assertEqual(list(self.pdb.items()), [('1234', 'Another_Platform'), ('0123', 'Base_Platform')])
+        self.assertEqual(set(self.pdb.all_ids()), set(['0123', '1234']))
+        self.assertBaseUnchanged()
+
+    def test_add_override(self):
+        """Check that adding a platform goes to the Override database and
+        you can no longer query for the base database definition and
+        that the override database was not written to disk
+        """
+        self.pdb.add('0123', 'Overriding_Platform')
+        self.assertIn(('0123', 'Overriding_Platform'), list(self.pdb.items()))
+        self.assertEqual(set(self.pdb.all_ids()), set(['0123']))
+        self.assertEqual(self.pdb.get('0123'), 'Overriding_Platform')
+        self.assertOverrideUnchanged()
+        self.assertBaseUnchanged()
+
+    def test_add_override_permanent(self):
+        """Check that adding a platform goes to the Override database and
+        you can no longer query for the base database definition and
+        that the override database was written to disk
+        """
+        self.pdb.add('0123', 'Overriding_Platform', permanent=True)
+        self.assertIn(('0123', 'Overriding_Platform'), list(self.pdb.items()))
+        self.assertEqual(set(self.pdb.all_ids()), set(['0123']))
+        self.assertEqual(self.pdb.get('0123'), 'Overriding_Platform')
+        self.overriding_db.seek(0)
+        self.assertEqual(self.overriding_db.read(),
+                         json.dumps(dict([('0123', 'Overriding_Platform')]))
+                         .encode('utf-8'))
+        self.assertBaseUnchanged()
+
+    def test_remove_override(self):
+        """Check that removing a platform from the Override database allows you to query
+        the original base database definition and that
+        that the override database was not written to disk
+        """
+        self.pdb.add('0123', 'Overriding_Platform')
+        self.assertIn(('0123', 'Overriding_Platform'), list(self.pdb.items()))
+        self.assertEqual(set(self.pdb.all_ids()), set(['0123']))
+        self.assertEqual(self.pdb.get('0123'), 'Overriding_Platform')
+        self.assertEqual(self.pdb.remove('0123'), 'Overriding_Platform')
+        self.assertEqual(self.pdb.get('0123'), 'Base_Platform')
+        self.assertOverrideUnchanged()
+        self.assertBaseUnchanged()
+
+    def test_remove_from_base(self):
+        """Check that removing a platform from the base database no longer allows you to query
+        the original base database definition and that that the base database
+        was not written to disk
+        """
+        self.assertEqual(self.pdb.remove('0123'), 'Base_Platform')
+        self.assertEqual(self.pdb.get('0123'), None)
+        self.assertOverrideUnchanged()
+        self.assertBaseUnchanged()
+
+    def test_remove_from_base_permanent(self):
+        """Check that removing a platform from the base database no longer allows you to query
+        the original base database definition and that that the base database
+        was not modified on disk
+        """
+        self.assertEqual(self.pdb.remove('0123', permanent=True), 'Base_Platform')
+        self.assertEqual(self.pdb.get('0123'), None)
+        self.assertBaseUnchanged()
+
+class InternalLockingChecks(unittest.TestCase):
+
+    def setUp(self):
+        self.mocked_lock = patch('mbed_lstools.platform_database.InterProcessLock', spec=True).start()
+        self.acquire = self.mocked_lock.return_value.acquire
+        self.release = self.mocked_lock.return_value.release
+        self.base_db = tempfile.NamedTemporaryFile(prefix='base')
+        self.base_db.write(b'{}')
+        self.base_db.seek(0)
+        self.pdb = PlatformDatabase([self.base_db.name])
+        self.addCleanup(patch.stopall)
+
+    def tearDown(self):
+        pass
+
+    def test_no_update(self):
+        """Test that no locks are used when no modifications are specified
+        """
+        self.pdb.add('7155', 'Junk')
+        self.acquire.assert_not_called()
+        self.release.assert_not_called()
+
+    def test_update(self):
+        """Test that locks are used when modifications are specified
+        """
+        self.pdb.add('7155', 'Junk', permanent=True)
+        assert self.acquire.called, 'Lock acquire should have been called'
+        assert self.release.called
+
+    def test_update_fail_acquire(self):
+        """Test that the backing file is not updated when lock acquisition fails
+        """
+        self.acquire.return_value = False
+        self.pdb.add('7155', 'Junk', permanent=True)
+        assert self.acquire.called, 'Lock acquire should have been called'
+        self.base_db.seek(0)
+        self.assertEqual(self.base_db.read(), b'{}')


### PR DESCRIPTION
Resolves #164  
Partial of #163 

This PR strips mocking functionality out of the MbedLsToolsBase class (what a name :( ) and makes a new module that is responsible for doing the database management. 

This new class, PlatformDatabase, accepts multiple files to build a database from and marks one of them as the primary_database. All new platforms are added to the primary db, and platform removals are done from all dbs. Only updates to the primary database are synced with the file system. When modifying a database, all accesses are synchronized with a file system lock (including all modifications of the mocks and the platform database in the user's home dir)

Coverage of this new file is 97%