### PR TITLE
Fixes --version option (removes exception)

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -45,6 +45,7 @@ class MbedLsToolsBase:
     RETARGET_FILE_NAME = 'mbedls.json'
     DETAILS_TXT_NAME = 'DETAILS.TXT'
     MBED_HTM_NAME = 'mbed.htm'
+    ERRORLEVEL_FLAG = 0
 
     def __init__(self, **kwargs):
         """ ctor


### PR DESCRIPTION
If you run `mbedls --version` on master, you get this at the moment:

```
$ mbedls --version
1.2.15
Traceback (most recent call last):
  File "/usr/local/bin/mbedls", line 11, in <module>
    load_entry_point('mbed-ls', 'console_scripts', 'mbedls')()
  File "/home/bridan01/dev/mbed-ls/mbed_lstools/main.py", line 247, in mbedls_main
    logger.debug("Return code: %d", mbeds.ERRORLEVEL_FLAG)
AttributeError: 'MbedLsToolsLinuxGeneric' object has no attribute 'ERRORLEVEL_FLAG'
```

**Ewww!**

This patch fixes this.

It looks like this now:

```
$ mbedls --version
1.2.15
```