### PR TITLE
Removing incorrect warning about unmounted devices on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ Extended mbedls API example:
  'list_platforms_ext',
  'load_mbed_description',
  'manufacture_ids',
- 'os_supported',
  'regbin2str',
  'scan_html_line_for_target_id',
  'usb_vendor_list',

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -57,10 +57,6 @@ class MbedLsToolsBase(object):
 
     __metaclass__ = ABCMeta
 
-    # Which OSs are supported by this module
-    # Note: more than one OS can be supported by mbed-lstools_* module
-    os_supported = []
-
     # Directory where we will store global (OS user specific mocking)
     HOME_DIR = expanduser("~")
     MOCK_FILE_NAME = '.mbedls-mock'
@@ -134,7 +130,8 @@ class MbedLsToolsBase(object):
             if  ((not device['mount_point'] or
                   not self.mount_point_ready(device['mount_point'])) and
                  not self.list_unmounted):
-                if  (device['target_id_usb_id'] and device['serial_port']):
+                if  (device['target_id_usb_id'] and device['serial_port']
+                    and self.__class__.__name__ != 'MbedLsToolsWin7'):
                     logger.warning(
                         "MBED with target id '%s' is connected, but not mounted. "
                         "Use the '-u' flag to include it in the list.",

--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -36,7 +36,6 @@ class MbedLsToolsWin7(MbedLsToolsBase):
     """
     def __init__(self, **kwargs):
         MbedLsToolsBase.__init__(self, **kwargs)
-        self.os_supported.append('Windows7')
 
     def find_candidates(self):
         return [

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -346,4 +346,3 @@ class LinuxPortTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -50,8 +50,12 @@ class Win7TestCase(unittest.TestCase):
         _winreg.SetValueEx.reset_mock()
         _winreg.SaveKey.reset_mock()
 
-    def test_os_supported(self):
-        pass
+    '''
+    This test case is necessary as some logging output is irrelavent when the
+    tool is running on Windows and the class name is used to detect this
+    '''
+    def test_class_name(self):
+        self.assertEqual(self.lstool.__class__.__name__, 'MbedLsToolsWin7')
 
     def test_empty_reg(self):
         _winreg.QueryInfoKey.return_value = (0, 0)


### PR DESCRIPTION
Noticed this extra (and incorrect) logging in the logs posted here: https://github.com/ARMmbed/greentea/issues/241#issuecomment-336115932

The particular warning really only applies to Mac and Linux since they have a similar concept of mounted/unmounted. It does not apply to Windows.