### PR TITLE
Allowing testing on Windows

### DIFF
--- a/mbed_lstools/linux.py
+++ b/mbed_lstools/linux.py
@@ -17,7 +17,7 @@ limitations under the License.
 
 import re
 from os.path import join, isdir, dirname, abspath
-from os import listdir, readlink
+import os
 
 from .lstools_base import MbedLsToolsBase
 
@@ -26,7 +26,7 @@ logger = logging.getLogger("mbedls.lstools_linux")
 del logging
 
 def _readlink(link):
-    content = readlink(link)
+    content = os.readlink(link)
     if content.startswith(".."):
         return abspath(join(dirname(link), content))
     else:
@@ -67,7 +67,7 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         """
         dir = join("/dev", device_type, "by-id")
         if isdir(dir):
-            to_ret = dict(self._hex_ids([join(dir, f) for f in listdir(dir)]))
+            to_ret = dict(self._hex_ids([join(dir, f) for f in os.listdir(dir)]))
             logger.debug("Found %s devices by id %r", device_type, to_ret)
             return to_ret
         else:

--- a/test/os_linux_generic.py
+++ b/test/os_linux_generic.py
@@ -80,8 +80,8 @@ class LinuxPortTestCase(unittest.TestCase):
 
     def find_candidates_with_patch(self, mount_list, link_dict, listdir_dict):
         with patch('mbed_lstools.linux.MbedLsToolsLinuxGeneric._run_cli_process') as _cliproc,\
-             patch('mbed_lstools.linux.readlink') as _readlink,\
-             patch('mbed_lstools.linux.listdir') as _listdir,\
+             patch('os.readlink') as _readlink,\
+             patch('os.listdir') as _listdir,\
              patch('mbed_lstools.linux.isdir') as _isdir:
             _isdir.return_value = True
             _cliproc.return_value = (b'\n'.join(mount_list), None, 0)
@@ -346,4 +346,3 @@ class LinuxPortTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    


### PR DESCRIPTION
Previously the Linux implementation selectively imported `readlink` from the `os` module. Now we just import `os` and use `os.readlink` within the Linux implementation when we're ready. But this prevents the error at input time.