### PR TITLE
Release version 1.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf8").read()
 
 setup(name='mbed-ls',
-      version='1.2.15',
+      version='1.3.2',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,


### PR DESCRIPTION
Fixes:
 - Show unknown boards/devices
 - Show devices as unknown in bootloader mode
 - Run generic setup before anything else in main
 - Prevent any use of the root logger
 - Allow windows users to run the test suite
 - Use "fsutil" to verify that the devices are connected on windows

Resolves #236 