### PR TITLE
Fix language matching in Windows

### DIFF
--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -120,8 +120,11 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         logger.debug('output: %s' % stdout)
 
         if not retval:
-            drive_list = re.match('\s*Drives: (.*)', stdout.decode('utf-8')).group(1)
-            return drive_list.strip().replace('\\', '').split(' ')
+            split_index = stdout.find(b':') + 1
+            drive_list = stdout[split_index:]
+            drive_list = drive_list.strip().replace(b'\\', b'').split(b' ')
+            drive_list = [d.decode('utf-8') for d in drive_list]
+            return drive_list
         return []
 
 

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding: utf-8
 """
 mbed SDK
 Copyright (c) 2011-2015 ARM Limited
@@ -150,6 +151,12 @@ class Win7TestCase(unittest.TestCase):
             self.assertNoRegMut()
 
             _cliproc.return_value = (b'\nDrives: C:\ F:\ Z:\ \n', None, 0)
+            devices = self.lstool.find_candidates()
+            self.assertNotIn(expected_info, devices)
+            self.assertNoRegMut()
+
+            # Test multilanguage support
+            _cliproc.return_value = (u'\nドライブ: C:\ F:\ Z:\ \n'.encode('shift_jis'), None, 0)
             devices = self.lstool.find_candidates()
             self.assertNotIn(expected_info, devices)
             self.assertNoRegMut()


### PR DESCRIPTION
Fixes #259.

Previously the Windows implementation relied on the language of the system to work correctly (specifically, English). This dependency has been removed. It should work on all languages now.