### PR TITLE
Remove use of 'fsutil' during Windows detection

### DIFF
--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -29,6 +29,30 @@ sys.modules['winreg'] = _winreg
 
 from mbed_lstools.windows import MbedLsToolsWin7
 
+def _mounted_drives_check(drives):
+    """! Function to generate fake 'dir <drive letter>' responses
+    @param drives Array of paths that should be considered mounted
+    @return Returns Function that accepts an array that would be passed
+    to _run_cli_process (ex ['dir', '<drive letter>']). Result of
+    function mimics the result of _run_cli_process.
+    """
+    def cli(cmd):
+        for drive in drives:
+            if drive.startswith(cmd[1]):
+                break
+        else:
+            return (None,
+                    'The system cannot find the path specified.',
+                    1)
+
+        return (('10/17/2017  12:27 PM    <DIR>          .\n'
+                '10/17/2017  12:27 PM    <DIR>          ..'),
+                None,
+                0)
+
+    return cli
+
+
 class Win7TestCase(unittest.TestCase):
     """ Basic test cases checking trivial asserts
     """
@@ -146,30 +170,6 @@ class Win7TestCase(unittest.TestCase):
                 'serial_port': 'COM7',
                 'target_id_usb_id': u'000440035522'
             }
-
-
-            def _mounted_drives_check(drives):
-                """! Function to generate fake 'dir <drive letter>' responses
-                @param drives Array of paths that should be considered mounted
-                @return Returns Function that accepts an array that would be passed
-                to _run_cli_process (ex ['dir', '<drive letter>']). Result of
-                function mimics the result of _run_cli_process.
-                """
-                def cli(cmd):
-                    for drive in drives:
-                        if drive.startswith(cmd[1]):
-                            break
-                    else:
-                        return (None,
-                                'The system cannot find the path specified.',
-                                1)
-
-                    return (('10/17/2017  12:27 PM    <DIR>          .\n'
-                            '10/17/2017  12:27 PM    <DIR>          ..'),
-                            None,
-                            0)
-
-                return cli
 
             _cliproc.side_effect = _mounted_drives_check(['C:', 'D:', 'F:', 'Z:'])
             devices = self.lstool.find_candidates()

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -157,11 +157,8 @@ class Win7TestCase(unittest.TestCase):
                 """
                 def cli(cmd):
                     for drive in drives:
-                        try:
-                            _ = os.path.relpath(cmd[1], drive)
+                        if drive.startswith(cmd[1]):
                             break
-                        except ValueError:
-                            pass
                     else:
                         return (None,
                                 'The system cannot find the path specified.',


### PR DESCRIPTION
Should fix #263 and #264.

In #241, I modified the detection process for Windows to use the [fsutil](https://technet.microsoft.com/en-us/library/cc753059(v=ws.11).aspx) program that ships with Windows. It provides a very fast way to detect what drive letters are currently available on the system. However, I missed this very important fact (spelled out in plain ol' English on their doc page):

> You must be logged on as an administrator or a member of the Administrators group to use fsutil. The fsutil command is quite powerful and should be used only by advanced users who have a thorough knowledge of Windows operating systems.

😞 

This PR changes the drive detection to the following:
- Take the results that are returned from the registry query
    - This includes mountpoints that may or may not be present on the system
- Loop over each mountpoint and call the Windows `dir` command
    - If it fails, don't include it in the returned list
    - The downside to this approach is we have to make more system calls
         - "But why not just use `os.path.exists` ?!?!"
         - If you call that function on a drive that is in the ejected state (happens directly after flashing), Python will throw a **blocking error box** and halt, and the workaround [isn't that great](https://stackoverflow.com/a/4790310/1493711)
    - The upside is this doesn't require administrator privileges


FYI @toyowata @MarceloSalazar 