### PR TITLE
Fix retargeting bug when using mbedls.json

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -158,8 +158,9 @@ class MbedLsToolsBase(object):
                                        for f, v in details_txt.items()})
                     try:
                         device.update(self.retarget_data[device['target_id']])
-                        logger.debug("retargeting %s to %s",
-                                     device['target_id'], mbeds[i])
+                        logger.debug("retargeting %s with %r",
+                                     device['target_id'],
+                                     self.retarget_data[device['target_id']])
                     except KeyError:
                         pass
                     result.append(maybe_device)


### PR DESCRIPTION
A NamesError exception is caused because some variables are not defined.
Changes the debug output. Fixes #268.