### PR TITLE
Replace name filter with function

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -117,6 +117,7 @@ class MbedLsToolsBase(object):
           trade of between quality of service and speed
         @param filter_function Function that is passed each mbed candidate,
           should return True if it should be included in the result
+          Ex. mbeds = list_mbeds(filter_function=lambda m: m['platform_name'] == 'K64F')
         @param unique_names A boolean controlling the presence of the
           'platform_unique_name' member of the output dict
         @param read_details_text A boolean controlling the presense of the


### PR DESCRIPTION
This was written in response to the issues brought up in #277.

This replaces the `platform_name_filter` option with a `filter_function`. This now allows you to filter mbed devices by any available data point, not just the platform name.

This is _technically_ a breaking API change, but the filter option was only recently added and I don't think it has wide spread adoption.

FYI @jupe @theotherjimmy 