### PR TITLE
Windows detection update

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -275,10 +275,6 @@ class MbedLsToolsBase(object):
         self.retarget_data = self.retarget_read()
         return self.retarget_data
 
-    # Note: 'Ven_SEGGER' - This is used to detect devices from EFM family, they use Segger J-LInk to wrap MSD and CDC
-    usb_vendor_list = ['Ven_MBED', 'Ven_SEGGER', 'Ven_ARM_V2M']
-
-
     def get_dummy_platform(self, platform_name):
         """! Returns simple dummy platform """
         if not hasattr(self, "dummy_counter"):

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -92,7 +92,7 @@ class MbedLsToolsBase(object):
 
         Note: Should not open any files
 
-        @return A dict with the keys 'mount_point', 'serial_port' and 'usb_target_id'
+        @return A dict with the keys 'mount_point', 'serial_port' and 'target_id_usb_id'
         """
         raise NotImplemented
 

--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -311,3 +311,23 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         logger.debug("iter_vals %r", key)
         for i in range(winreg.QueryInfoKey(key)[1]):
             yield winreg.EnumValue(key, i)
+
+    def mount_point_ready(self, path):
+        """! Check if a mount point is ready for file operations
+        @return Returns True if the given path exists, False otherwise
+        @details Calling the Windows command `dir` instead of using the python
+        `os.path.exists`. The latter causes a Python error box to appear claiming
+        there is "No Disk" for some devices that are in the ejected state. Calling
+        `dir` prevents this since it uses the Windows API to determine if the
+        device is ready before accessing the file system.
+        """
+        stdout, stderr, retcode = self._run_cli_process('dir %s' % path)
+        result = True if retcode == 0 else False
+
+        if result:
+            logger.debug("Mount point %s is ready", path)
+        else:
+            logger.debug("Mount point %s reported not ready with error '%s'",
+                          path, stderr.strip())
+
+        return result

--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -33,6 +33,20 @@ if sys.version_info[0] < 3:
 else:
     import winreg
 
+def _composite_device_key(device):
+    """! Given two composite devices, return a ranking on its specificity
+    @return if no mount_point, then always 0. If mount_point but no serial_port,
+    return 1. If mount_point and serial_port, add the prefix_index.
+    """
+    rank = 0
+
+    if 'mount_point' in device:
+        rank += 1
+        if device['serial_port'] is not None:
+            rank += device['prefix_index']
+
+    return rank
+
 
 class MbedLsToolsWin7(MbedLsToolsBase):
     """ mbed-enabled platform detection for Windows
@@ -117,21 +131,6 @@ class MbedLsToolsWin7(MbedLsToolsBase):
             If a mass storage is present, a key of 'mount_point' should be returned
             with a value of None (to be completed later)
         """
-
-        def composite_device_key(device):
-            """! Given two composite devices, return a ranking on its specificity
-            @return if no mount_point, then always 0. If mount_point but no serial_port,
-            return 1. If mount_point and serial_port, add the prefix_index.
-            """
-            rank = 0
-
-            if 'mount_point' in device:
-                rank += 1
-                if device['serial_port'] is not None:
-                    rank += device['prefix_index']
-
-            return rank
-
 
         result = []
 
@@ -266,7 +265,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
                 logger.debug('Skipping device entry %s, %s' % (label, e))
                 continue
 
-            options.sort(key=composite_device_key, reverse=True)
+            options.sort(key=_composite_device_key, reverse=True)
 
             if len(options) == 0:
                 logger.debug('No options were found, skipping composite device')

--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -19,6 +19,7 @@ import re
 import os
 import sys
 import string
+import itertools
 
 from .lstools_base import MbedLsToolsBase
 
@@ -36,119 +37,215 @@ else:
 class MbedLsToolsWin7(MbedLsToolsBase):
     """ mbed-enabled platform detection for Windows
     """
+
+    _COMPOSITE_USB_SERVICES = ['usbccgp', 'mbedComposite']
+
     def __init__(self, **kwargs):
         MbedLsToolsBase.__init__(self, **kwargs)
         self.os_supported.append('Windows7')
 
+
     def find_candidates(self):
-        return [
-            {
-                'mount_point': mnt,
-                'target_id_usb_id': id,
-                'serial_port': self._com_port(id)
-            }
-            for mnt, id in self.get_mbeds()
-        ]
+        result = []
+        composite_devices = self._get_composite_devices()
+        if composite_devices:
+            volumes = self._get_volumes()
+            for composite_device in composite_devices:
+                tid = composite_device['target_id_usb_id']
+                found_index = None
+                for index, volume in enumerate(volumes):
+                    if volume['target_id_usb_id'] == tid:
+                        found_index = index
+                        composite_device.update(volume)
+                        result.append(composite_device)
 
-    def _com_port(self, tid):
-        """! Function checks mbed serial port in Windows registry entries
-        @param tid TargetID
-        @return Returns None if port is not found. In normal circumstances it should never return None
-        @details This goes through a whole new loop, but this assures that even if serial port (COM)
-                 is not detected, we still get the rest of info like mount point etc.
+                if found_index is not None:
+                    volumes.pop(found_index)
+        return result
+
+
+    def _get_volumes(self):
+        """! Get the volumes present on the system
+        @return List of mount points and their associated target id
+          Ex. [{ 'mount_point': 'D:', 'target_id_usb_id': 'xxxx'}, ...]
         """
-        winreg.Enum = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
-                                     r'SYSTEM\CurrentControlSet\Enum')
-        usb_devs = winreg.OpenKey(winreg.Enum, 'USB')
-        logger.debug("_com_port usb_devs %r",
-                     list(self.iter_keys_as_str(usb_devs)))
+        result = []
+        try:
+            # Open the registry key for mounted devices
+            mounted_devices_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                'SYSTEM\\MountedDevices')
+            for v in self.iter_vals(mounted_devices_key):
+                # Valid entries have the following format: \DosDevices\D:
+                if 'DosDevices' in v[0]:
+                    mount_point_match = re.match('.*\\\\(.:)$', v[0])
 
-        logger.debug("_com_port looking up usb id in all usb devices")
-        dev_keys = []
-        for name, vid in zip(self.iter_keys_as_str(usb_devs),
-                             self.iter_keys(usb_devs)):
+                    if not mount_point_match:
+                        logger.debug('Invalid disk pattern for entry %s, skipping' % v[0])
+                        continue
+
+                    # TargetID is a hex string with 10-48 chars
+                    entry_string = v[1].decode('utf-16le', 'ignore')
+                    target_id_match = re.search('[&#]([0-9A-Za-z]{10,48})[&#]', entry_string)
+                    if not target_id_match:
+                        logger.debug('Entry %s has invalid target id pattern '
+                            '%s, skipping' % (v[0], entry_string))
+                        continue
+
+                    result.append({
+                        'mount_point': mount_point_match.group(1),
+                        'target_id_usb_id': target_id_match.group(1)
+                    })
+        except OSError:
+            logger.error('Failed to open "MountedDevices" in registry')
+
+        return result
+
+
+    def _get_composite_devices(self):
+        """! Get connected composite USB devices
+        @return List of target ids and serial properties
+          Ex. [{ 'target_id_usb_id': 'xxxx', 'serial_port': 'COMxx', 'mount_point': None }, ...]
+        @details The composite devices are required to have a mass storage device.
+            If a mass storage is present, a key of 'mount_point' should be returned
+            with a value of None (to be completed later)
+        """
+        result = []
+
+        # Open the root registry key
+        try:
+            control_set_key_string = "SYSTEM\\CurrentControlSet"
+            control_set_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                control_set_key_string)
+        except OSError:
+            logger.error('Could not find "%s" in registry' % control_set_key_string)
+            return []
+
+        # Enumerate all USB VID/PID pairs
+        try:
+            vid_pid_key = winreg.OpenKey(control_set_key, 'Enum\\USB')
+            vid_pid_keys = list(self.iter_keys_as_str(vid_pid_key))
+        except OSError:
+            logger.error('Could not enumerate USB VID/PID pairs')
+            return []
+
+        # Find all composite USB services
+        found_composite_keys = []
+        for usb_service in self._COMPOSITE_USB_SERVICES:
             try:
-                dev_keys.append(winreg.OpenKey(vid, tid))
-                if logger.isEnabledFor(DEBUG):
-                    logger.debug(
-                        "Found usb id %s in %s with subkeys %r", tid, name,
-                        list(self.iter_keys_as_str(winreg.OpenKey(vid, tid))))
+                found_composite_keys.append(winreg.OpenKey(control_set_key,
+                    'Services\\%s\\Enum' % usb_service))
             except OSError:
-                pass
+                logger.debug('Composite USB service "%s" not found' % usb_service)
 
-        logger.debug("_com_port Detecting port with Device Parameter")
-        for key in dev_keys:
+        # Find all enumerated composite USB devices
+        composite_iter_vals = [self.iter_vals(k) for k in found_composite_keys]
+        for point, label, _ in itertools.chain.from_iterable(composite_iter_vals):
             try:
-                param = winreg.OpenKey(key, "Device Parameters")
-                port, regtype = winreg.QueryValueEx(param, 'PortName')
-                logger.debug('_com_port port %r regtype %r', port, regtype)
-                return port
-            except OSError as e:
-                logger.debug("Exception %r %s", key, str(e))
-                pass
+                # These keys in the registry enumerate all composite DosDevices
+                # as a value with an integer. This check ensures we ignore a few
+                # helper values in the registry key.
+                _ = int(point)
+            except ValueError:
+                continue
 
-        logger.debug("_com_port Detecting port by following symlinks")
-        for key in dev_keys:
+            label_parts = label.split('\\')
+
+            # The expected format is "USB\VID_XXXX&PID_XXXX\<target id>"
+            if len(label_parts) != 3:
+                logger.debug('Unrecognized device path %s' % label)
+                continue
+
+            if label_parts[0] != 'USB':
+                logger.debug('Expected device to be under "USB", '
+                    'actual location was "%s"' % label_parts[0])
+                continue
+
+            vid_pid_prefix = label_parts[1]
+            target_id_usb_id = label_parts[2]
+
+            mbed = {
+                'target_id_usb_id': target_id_usb_id,
+                'serial_port': None
+            }
+
             try:
-                ports = []
-                parent_id, regtype = winreg.QueryValueEx(key, 'ParentIdPrefix')
-                logger.debug("_com_port parent_id %r regtype %r")
-                for VID in self.iter_keys(usb_devs):
-                    candidate_keys = [k for k in self.iter_keys_as_str(VID)
-                                      if parent_id in k]
-                    for dev in candidate_keys:
-                        logger.debug(
-                            "_com_port recursive port detection with %r", dev)
-                        maybe_port = self._com_port(dev)
-                        if maybe_port:
-                            return maybe_port
+                composite_key_string = '%s\\%s' % (vid_pid_prefix, target_id_usb_id)
+                logger.debug('Composite device at key %s' % composite_key_string)
+                composite_key = winreg.OpenKey(vid_pid_key, composite_key_string)
+                try:
+                    parent_id_prefix, _ = winreg.QueryValueEx(composite_key,
+                        'ParentIdPrefix')
+                except OSError:
+                    logger.debug('No ParentIdPrefix found, '
+                        'falling back to target_id_usb_id')
+                    parent_id_prefix = target_id_usb_id
+
+                vid_pid_matches = [
+                    m for m in vid_pid_keys
+                    if m.startswith(vid_pid_prefix) and m != vid_pid_prefix
+                ]
+
+                for vid_pid_match in vid_pid_matches:
+                    logger.debug('Endpoint parent at key %s' % vid_pid_match)
+                    endpoint_parent_key = winreg.OpenKey(vid_pid_key, vid_pid_match)
+
+                    candidates = [
+                        c for c in list(self.iter_keys_as_str(endpoint_parent_key))
+                        if c.startswith(parent_id_prefix)
+                    ]
+
+                    if len(candidates) == 0:
+                        logger.warning('No candidate found for parent_id_prefix'
+                            ' %s' % parent_id_prefix)
+                        break
+                    elif len(candidates) > 1:
+                        logger.warning('Unexpectedly found two candidates %s' % candidates)
+                        logger.warning('Picking %s and continuing' % candidates[0])
+
+                    endpoint_key_string = '%s\\%s' % (vid_pid_match, candidates[0])
+                    logger.debug('Endpoint at key %s' % endpoint_key_string)
+                    endpoint_key = winreg.OpenKey(vid_pid_key, endpoint_key_string)
+
+                    # This verifies that a USB Storage device is associated with
+                    # the composite device
+                    if not 'mount_point' in mbed:
+                        try:
+                            service, _ = winreg.QueryValueEx(endpoint_key, 'Service')
+                            if service.upper() == 'USBSTOR':
+                                mbed['mount_point'] = None
+                                continue
+                        except OSError:
+                            pass
+
+                    # This adds the serial port information for the device if
+                    # it is availble
+                    if mbed['serial_port'] is None:
+                        try:
+                            device_parameters_key = winreg.OpenKey(endpoint_key,
+                                'Device Parameters')
+                            mbed['serial_port'], _ = winreg.QueryValueEx(
+                                device_parameters_key, 'PortName')
+                            continue
+                        except OSError:
+                            pass
+
             except OSError as e:
-                logger.debug("Exception %r %s", key, str(e))
-                pass
+                logger.debug('Skipping device entry %s, %s' % (label, e))
+                continue
 
-        # If everything fails, return None
-        return None
+            # A target_id_usb_id and mount point must be present to be included
+            # in the candidates
+            required_keys = set(['target_id_usb_id', 'mount_point'])
+            missing_keys = required_keys - set(mbed.keys())
+            if missing_keys:
+                logger.debug('Device %s missing keys %s, skipping' % (label,
+                    list(missing_keys)))
+            else:
+                logger.debug('Candidate found %s' % label)
+                result.append(mbed)
 
+        return result
 
-    def _mount_point_exists(self, mountpoint):
-        """! Function returns if the mountpoint exists
-        @param mountpoint Path of mountpoint
-        @return Returns True if mountpoint exists, otherwise False
-        @details This uses a Windows subcommand to avoid throwing a Python
-        error box when the device is in an ejected state.
-        """
-        cmd = ['dir', mountpoint]
-        logger.debug('running command: %s' % (' '.join(cmd)))
-        stdout, stderr, retval = self._run_cli_process(cmd)
-
-        if not retval:
-            logger.debug("mountpoint %s ready" % mountpoint)
-        else:
-            logger.debug("mountpoint %s reported not ready with error '%s'" %
-                (mountpoint, stderr.strip()))
-
-        return not retval
-
-
-    def get_mbeds(self):
-        """! Function filters devices' mount points for valid TargetID
-        @return Returns [(<mbed_mount_point>, <mbed_id>), ..]
-        @details TargetID should be a hex string with 10-48 chars
-        """
-        mbeds = []
-        for mbed in self.get_mbed_devices():
-            mountpoint = re.match('.*\\\\(.:)$', mbed[0]).group(1)
-            logger.debug('Registry mountpoint %s', mountpoint)
-
-            if self._mount_point_exists(mountpoint):
-                # TargetID is a hex string with 10-48 chars
-                m = re.search('[&#]([0-9A-Za-z]{10,48})[&#]', mbed[1])
-                if not m:
-                    continue
-                tid = m.group(1)
-                mbeds += [(mountpoint, tid)]
-                logger.debug("get_mbeds mount_point %s usb_id %s", mountpoint, tid)
-        return mbeds
 
     # =============================== Registry ====================================
 
@@ -158,11 +255,13 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         for i in range(winreg.QueryInfoKey(key)[0]):
             yield winreg.EnumKey(key, i)
 
+
     def iter_keys(self, key):
         """! Iterate over subkeys of a key
         """
         for i in range(winreg.QueryInfoKey(key)[0]):
             yield winreg.OpenKey(key, winreg.EnumKey(key, i))
+
 
     def iter_vals(self, key):
         """! Iterate over values of a key
@@ -170,21 +269,3 @@ class MbedLsToolsWin7(MbedLsToolsBase):
         logger.debug("iter_vals %r", key)
         for i in range(winreg.QueryInfoKey(key)[1]):
             yield winreg.EnumValue(key, i)
-
-    def get_mbed_devices(self):
-        """! Get MBED devices (connected or not)
-        @return List of devices
-        @details Note: We will detect also non-standard MBED devices mentioned on 'usb_vendor_list' list.
-                 This will help to detect boards like EFM boards.
-        """
-        upper_ven = [ven.upper() for ven in self.usb_vendor_list]
-        mounts_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, 'SYSTEM\MountedDevices')
-        for point, label, _ in self.iter_vals(mounts_key):
-            printable_label = label.decode('utf-16le', 'ignore')
-            if ('DosDevices' in point and
-                any(v in printable_label.upper() for v in upper_ven)):
-                logger.debug("Found Mount point %s with usb ID %s",point,
-                             printable_label)
-                yield (point, printable_label)
-            else:
-                logger.debug("Skipping Mount point %r label %r", point, label)

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -20,7 +20,7 @@ limitations under the License.
 import unittest
 import sys
 import os
-from mock import MagicMock, patch
+from mock import MagicMock, patch, call
 
 # Mock the winreg and _winreg module for non-windows python
 _winreg = MagicMock()
@@ -28,30 +28,6 @@ sys.modules['_winreg']  = _winreg
 sys.modules['winreg'] = _winreg
 
 from mbed_lstools.windows import MbedLsToolsWin7
-
-def _mounted_drives_check(drives):
-    """! Function to generate fake 'dir <drive letter>' responses
-    @param drives Array of paths that should be considered mounted
-    @return Returns Function that accepts an array that would be passed
-    to _run_cli_process (ex ['dir', '<drive letter>']). Result of
-    function mimics the result of _run_cli_process.
-    """
-    def cli(cmd):
-        for drive in drives:
-            if drive.startswith(cmd[1]):
-                break
-        else:
-            return (None,
-                    'The system cannot find the path specified.',
-                    1)
-
-        return (('10/17/2017  12:27 PM    <DIR>          .\n'
-                '10/17/2017  12:27 PM    <DIR>          ..'),
-                None,
-                0)
-
-    return cli
-
 
 class Win7TestCase(unittest.TestCase):
     """ Basic test cases checking trivial asserts
@@ -78,12 +54,33 @@ class Win7TestCase(unittest.TestCase):
         pass
 
     def test_empty_reg(self):
-        _winreg.QueryInfoKey.return_value = (0, 0)
-        self.lstool.find_candidates()
-        _winreg.OpenKey.assert_called_with(_winreg.HKEY_LOCAL_MACHINE,
-                                           'SYSTEM\MountedDevices')
-        _winreg.QueryInfoKey.assert_called_with(_winreg.OpenKey.return_value)
-        pass
+        value_dict = {
+            (None, 'SYSTEM\\MountedDevices'): [
+                ('\\DosDevices\\F:',
+                 u'_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#0240000032044e4500367009997b00086781000097969900&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'.encode('utf-16le')),
+                ('\\DosDevices\\D:',
+                 u'_??_USBSTOR#Disk&Ven_SEGGER&Prod_MSD_Volume&Rev_1.00#8&1b8e102b&0&000440035522&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'.encode('utf-16le'))],
+            ((None, 'SYSTEM\\CurrentControlSet'), 'Services\\usbccgp\\Enum'): [
+                ('Count', 0),
+                ('NextInstance', 0)
+            ]
+        }
+        key_dict = {
+            (None, 'SYSTEM\\CurrentControlSet'): ['Services\\usbccgp\\Enum'],
+            (None, 'SYSTEM\\CurrentControlSet'): ['Enum\\USB'],
+            ((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'):
+            ['ROOT_HUB30', 'VID_0416&PID_511E', 'VID_0416&PID_511E&MI_00',
+             'VID_8087&PID_0A2B', 'Vid_80EE&Pid_CAFE']
+        }
+        self.setUpRegistry(value_dict, key_dict)
+        candidates = self.lstool.find_candidates()
+        self.assertEqual(_winreg.OpenKey.mock_calls, [
+            call(_winreg.HKEY_LOCAL_MACHINE, 'SYSTEM\\CurrentControlSet'),
+            call((_winreg.HKEY_LOCAL_MACHINE, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+            call((_winreg.HKEY_LOCAL_MACHINE, 'SYSTEM\\CurrentControlSet'), 'Services\\usbccgp\\Enum'),
+            call((_winreg.HKEY_LOCAL_MACHINE, 'SYSTEM\\CurrentControlSet'), 'Services\\mbedComposite\\Enum')
+        ])
+        self.assertEqual(candidates, [])
 
     def assertNoRegMut(self):
         """Assert that the registry was not mutated in this test"""
@@ -128,20 +125,45 @@ class Win7TestCase(unittest.TestCase):
                     len(value_dict.get(key, [])))
         _winreg.QueryInfoKey.side_effect = query_info_key
 
-    def test_one_nucleo_dev(self):
+    def test_one_dev(self):
         value_dict = {
-            (None, 'SYSTEM\MountedDevices'): [
+            (None, 'SYSTEM\\MountedDevices'): [
+                ('\\DosDevices\\C:', u'NOT A VALID MBED DRIVE'.encode('utf-16le')),
                 ('\\DosDevices\\F:',
-                 u'_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#0240000032044e4500367009997b00086781000097969900&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'.encode('utf-16le')),
-                ('\\DosDevices\\D:',
-                 u'_??_USBSTOR#Disk&Ven_SEGGER&Prod_MSD_Volume&Rev_1.00#8&1b8e102b&0&000440035522&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'.encode('utf-16le'))],
-            ((((((None, 'SYSTEM\CurrentControlSet\Enum'), 'USB'),
-                'VID_0416&PID_511E'), '000440035522'), 'Device Parameters'), 'PortName'): ('COM7', None)
+                 u'_??_USBSTOR#Disk&Ven_MBED&Prod_VFS&Rev_0.1#11010000442031204c364141303031313431303397969903&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}'.encode('utf-16le'))
+            ],
+            ((None, 'SYSTEM\\CurrentControlSet'), 'Services\\usbccgp\\Enum'): [
+                ('0', 'USB\\VID_5986&PID_0706\\5&31ac2c0b&0&8'),
+                ('Count', 2),
+                ('NextInstance', 2)
+            ],
+            ((None, 'SYSTEM\\CurrentControlSet'), 'Services\\mbedComposite\\Enum'): [
+                ('0', 'USB\\VID_0D28&PID_0204\\11010000442031204c364141303031313431303397969903'),
+                ('Count', 1),
+                ('NextInstance', 1)
+            ],
+            ((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'), 'VID_5986&PID_0706\\5&31ac2c0b&0&8'), 'ParentIdPrefix'): ('6&3beba67&0', None),
+            ((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'), 'VID_5986&PID_0706&MI_00\\6&3beba67&0&0000'),
+                'Service'): ('SPUVCbv', None),
+            (((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204\\11010000442031204c364141303031313431303397969903'): [],
+            ((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_00\\11010000442031204c364141303031313431303397969903'),
+                'Service'): ('USBSTOR', None),
+            ((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_01\\11010000442031204c364141303031313431303397969903'),
+                'Device Parameters'): [('PortName', 'COM7')],
+            (((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_01\\11010000442031204c364141303031313431303397969903'),
+                'Device Parameters'), 'PortName'): ('COM7', None),
+            ((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_03\\11010000442031204c364141303031313431303397969903'),
+                'Service'): ('HidUsb', None)
         }
         key_dict = {
-            (None, 'SYSTEM\CurrentControlSet\Enum'): ['USB'],
-            ((((None, 'SYSTEM\CurrentControlSet\Enum'), 'USB'), 'VID_0416&PID_511E'), '000440035522'): ['Device Parameters', 'Properties'],
-            ((None, 'SYSTEM\CurrentControlSet\Enum'), 'USB'):
+            (None, 'SYSTEM\\CurrentControlSet'): ['Services\\usbccgp\\Enum', 'Services\\mbedComposite\\Enum'],
+            (None, 'SYSTEM\\CurrentControlSet'): ['Enum\\USB'],
+            ((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'):
             ['ROOT_HUB30', 'VID_0416&PID_511E', 'VID_0416&PID_511E&MI_00',
              'VID_0416&PID_511E&MI_01', 'VID_046D&PID_C03D',
              'VID_046D&PID_C313', 'VID_046D&PID_C313&MI_00',
@@ -160,27 +182,30 @@ class Win7TestCase(unittest.TestCase):
              'VID_195D&PID_2047&MI_02', 'VID_1A40&PID_0101', 'VID_1FD2&PID_5003',
              'VID_1FD2&PID_5003&MI_00', 'VID_1FD2&PID_5003&MI_01',
              'VID_413C&PID_2107', 'VID_5986&PID_0706', 'VID_5986&PID_0706&MI_00',
-             'VID_8087&PID_0A2B', 'Vid_80EE&Pid_CAFE']
+             'VID_8087&PID_0A2B', 'Vid_80EE&Pid_CAFE'],
+            (((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_5986&PID_0706&MI_00'): ['6&3beba67&0&0000'],
+            (((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_00'): ['11010000442031204c364141303031313431303397969903'],
+            (((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_01'): ['11010000442031204c364141303031313431303397969903'],
+            ((((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_01'), '11010000442031204c364141303031313431303397969903'): ['Device Parameters'],
+            (((None, 'SYSTEM\\CurrentControlSet'), 'Enum\\USB'),
+                'VID_0D28&PID_0204&MI_03'): ['11010000442031204c364141303031313431303397969903']
         }
         self.setUpRegistry(value_dict, key_dict)
 
         with patch('mbed_lstools.windows.MbedLsToolsWin7._run_cli_process') as _cliproc:
             expected_info = {
-                'mount_point': u'D:',
+                'mount_point': u'F:',
                 'serial_port': 'COM7',
-                'target_id_usb_id': u'000440035522'
+                'target_id_usb_id': u'11010000442031204c364141303031313431303397969903'
             }
 
-            _cliproc.side_effect = _mounted_drives_check(['C:', 'D:', 'F:', 'Z:'])
             devices = self.lstool.find_candidates()
             self.assertIn(expected_info, devices)
             self.assertNoRegMut()
-
-            _cliproc.side_effect = _mounted_drives_check(['C:', 'F:', 'Z:'])
-            devices = self.lstool.find_candidates()
-            self.assertNotIn(expected_info, devices)
-            self.assertNoRegMut()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -197,6 +197,7 @@ class Win7TestCase(unittest.TestCase):
         self.setUpRegistry(value_dict, key_dict)
 
         with patch('mbed_lstools.windows.MbedLsToolsWin7._run_cli_process') as _cliproc:
+            _cliproc.return_value = ("", "", 0)
             expected_info = {
                 'mount_point': u'F:',
                 'serial_port': 'COM7',
@@ -206,6 +207,17 @@ class Win7TestCase(unittest.TestCase):
             devices = self.lstool.find_candidates()
             self.assertIn(expected_info, devices)
             self.assertNoRegMut()
+
+    def test_mount_point_ready(self):
+        with patch('mbed_lstools.windows.MbedLsToolsWin7._run_cli_process') as _cliproc:
+            _cliproc.return_value = ("dummy", "", 0)
+            self.assertTrue(self.lstool.mount_point_ready("dummy"))
+
+            _cliproc.reset_mock()
+
+            _cliproc.return_value = ("", "dummy", 1)
+            self.assertFalse(self.lstool.mount_point_ready("dummy"))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This was made in response to #279.

The Windows registry is responsible for keeping track of all USB
devices. Previously, we were using a portion of the registry that is
always cached, even if a device is removed. This caused certain network
drives to appear as mbeds if they attached to a previously attached
mbed's drive letter (network drives don't appear to update the registry).

Now we are checking the enumeration part of the registry to ensure the
device is actually plugged in before return it as a result.

This also has the benefit that we no longer need to call the subprocess `dir` for each potentially found device. This translate to an execution speed up! My preliminary tests show the speed up is on the order of 50-100ms.