### PR TITLE
Remove log calls to root logger

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -208,11 +208,11 @@ class MbedLsToolsBase(object):
             device.update({"daplink_%s" % f.lower().replace(' ', '_'): v
                            for f, v in daplink_info.items()})
         if htm_target_id:
-            logging.debug("Found htm target id, %s, for usb target id %s",
+            logger.debug("Found htm target id, %s, for usb target id %s",
                             htm_target_id, device['target_id_usb_id'])
             device['target_id'] = htm_target_id
         else:
-            logging.warning("Could not read htm on from usb id %s. "
+            logger.warning("Could not read htm on from usb id %s. "
                             "Falling back to usb id",
                             device['target_id_usb_id'])
             device['target_id'] = device['target_id_usb_id']
@@ -395,10 +395,10 @@ class MbedLsToolsBase(object):
                 try:
                     return json.load(data_file)
                 except ValueError as json_error_msg:
-                    logging.error("Parsing file(%s): %s", json_spec_filename, json_error_msg)
+                    logger.error("Parsing file(%s): %s", json_spec_filename, json_error_msg)
                     return None
         except IOError as fileopen_error_msg:
-            logging.warning(fileopen_error_msg)
+            logger.warning(fileopen_error_msg)
             return None
 
     @deprecated("This method will be removed from the public API. "


### PR DESCRIPTION
Fixes #285.

There were a few stray calls to the root logger. This caused complications when used with other modules that make use of the `logging` library. They are removed in this patch.

cc @theotherjimmy @jonikula