### PR TITLE
Jlink and other fw detection

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -204,9 +204,12 @@ class MbedLsToolsBase(object):
             return
 
         device['device_type'] = self._detect_device_type(device['mount_point'])
-
         device['target_id'] = device['target_id_usb_id']
-        self._update_device_details(device, include_extra_info)
+
+        {
+            'daplink': self._update_device_details_daplink,
+            'jlink': self._update_device_details_jlink
+        }[device['device_type']](device, include_extra_info)
 
     def _detect_device_type(self, mount_point):
         """ Returns a string of the device type
@@ -216,17 +219,6 @@ class MbedLsToolsBase(object):
         files = [f.lower() for f in os.listdir(mount_point)]
         return 'jlink' if 'segger.html' in files else 'daplink'
 
-    def _update_device_details(self, device, include_extra_info):
-        """ Updates device dict with information from the filesystem
-            @param device Device dictionary to update. Should contain a valid
-                'mount_point' value
-            @param include_extra_info Controls how much information (and by extension,
-                the performance) is returned from the filesystem
-        """
-        {
-            'daplink': self._update_device_details_daplink,
-            'jlink': self._update_device_details_jlink
-        }[device['device_type']](device, include_extra_info)
 
     def _update_device_details_daplink(self, device, include_extra_info):
         self._update_device_from_htm(device)

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -110,7 +110,7 @@ class MbedLsToolsBase(object):
     def list_mbeds(
             self, fs_interaction=FSInteraction.BeforeFilter,
             filter_function=None, unique_names=False,
-            read_details_txt=None):
+            read_details_txt=False):
         """ List details of connected devices
         @return Returns list of structures with detailed info about each mbed
         @param fs_interaction A member of the FSInteraction class that picks the
@@ -151,7 +151,6 @@ class MbedLsToolsBase(object):
                         platform_count[name] += 1
                         device['platform_name_unique'] = (
                             "%s[%d]" % (name, platform_count[name]))
-
                     try:
                         device.update(self.retarget_data[device['target_id']])
                         logger.debug("retargeting %s with %r",
@@ -188,7 +187,6 @@ class MbedLsToolsBase(object):
             return None
 
     def _fs_after_id_check(self, device, filter_function, read_details_txt):
-
         """Filter device before touching the file system of the device.
         Said another way: Touch the file system after filtering
         """
@@ -249,11 +247,9 @@ class MbedLsToolsBase(object):
         else:
             device['platform_name'] = None
 
-    def _update_device_details_jlink(self, device, read_details_txt):
+    def _update_device_details_jlink(self, device, _):
         """ Updates the jlink-specific device information based on files from its 'mount_point'
             @param device Dictionary containing device information
-            @param read_details_txt A boolean controlling the presense of the
-              output dict attributes read from other files present on the 'mount_point'
         """
         files = os.listdir(device['mount_point'])
         lower_case_map = {f.lower(): f for f in files}

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -177,6 +177,7 @@ class MbedLsToolsBase(object):
         """Filter device after touching the file system of the device.
         Said another way: Touch the file system before filtering
         """
+
         device['target_id'] = device['target_id_usb_id']
         self._update_device_from_fs(device, include_extra_info)
         if not filter_function or filter_function(device):
@@ -227,8 +228,11 @@ class MbedLsToolsBase(object):
             device.update({"daplink_%s" % f.lower().replace(' ', '_'): v
                            for f, v in details_txt.items()})
 
-        device['platform_name'] = self.plat_db.get(device['target_id'][0:4],
-                                                   device_type='daplink')
+        if device['target_id']:
+            device['platform_name'] = self.plat_db.get(device['target_id'][0:4],
+                                                       device_type='daplink')
+        else:
+            device['platform_name'] = None
 
     def _update_device_details_jlink(self, device, include_extra_info):
         files = os.listdir(device['mount_point'])
@@ -270,10 +274,6 @@ class MbedLsToolsBase(object):
                             device['target_id_usb_id'])
             device['target_id'] = device['target_id_usb_id']
         device['target_id_mbed_htm'] = htm_target_id
-        if device['target_id']:
-            device['platform_name'] = self.plat_db.get(device['target_id'][0:4])
-        else:
-            device['platform_name'] = None
 
     def mock_manufacture_id(self, mid, platform_name, oper='+'):
         """! Replace (or add if manufacture id doesn't exist) entry in self.manufacture_ids

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -200,6 +200,11 @@ class MbedLsToolsBase(object):
             return None
 
     def _update_device_from_fs(self, device, read_details_txt):
+        """ Updates the device information based on files from its 'mount_point'
+            @param device Dictionary containing device information
+            @param read_details_txt A boolean controlling the presense of the
+              output dict attributes read from other files present on the 'mount_point'
+        """
         if not device.get('mount_point', None):
             device['device_type'] = 'unknown'
             return
@@ -222,6 +227,11 @@ class MbedLsToolsBase(object):
 
 
     def _update_device_details_daplink(self, device, read_details_txt):
+        """ Updates the daplink-specific device information based on files from its 'mount_point'
+            @param device Dictionary containing device information
+            @param read_details_txt A boolean controlling the presense of the
+              output dict attributes read from other files present on the 'mount_point'
+        """
         self._update_device_from_htm(device)
         if read_details_txt:
             details_txt = self._details_txt(device['mount_point']) or {}
@@ -235,6 +245,11 @@ class MbedLsToolsBase(object):
             device['platform_name'] = None
 
     def _update_device_details_jlink(self, device, read_details_txt):
+        """ Updates the jlink-specific device information based on files from its 'mount_point'
+            @param device Dictionary containing device information
+            @param read_details_txt A boolean controlling the presense of the
+              output dict attributes read from other files present on the 'mount_point'
+        """
         files = os.listdir(device['mount_point'])
         lower_case_map = {f.lower(): f for f in files}
 

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -167,7 +167,9 @@ class MbedLsToolsBase(object):
         """Filter device without touching the file system of the device"""
         device['target_id'] = device['target_id_usb_id']
         device['target_id_mbed_htm'] = None
-        device['platform_name'] = self.plat_db.get(device['target_id'][0:4])
+        platform_data = self.plat_db.get(device['target_id'][0:4],
+                                         verbose_data=True)
+        device.update(platform_data or {'platform_name': None})
         if not filter_function or filter_function(device):
             return device
         else:
@@ -192,7 +194,8 @@ class MbedLsToolsBase(object):
         """
         device['target_id'] = device['target_id_usb_id']
         device['target_id_mbed_htm'] = None
-        device['platform_name'] = self.plat_db.get(device['target_id'][0:4])
+        platform_data = self.plat_db.get(device['target_id'][0:4], verbose_data=True)
+        device.update(platform_data or {'platform_name': None})
         if not filter_function or filter_function(device):
             self._update_device_from_fs(device, read_details_txt)
             return device
@@ -239,8 +242,10 @@ class MbedLsToolsBase(object):
                            for f, v in details_txt.items()})
 
         if device['target_id']:
-            device['platform_name'] = self.plat_db.get(device['target_id'][0:4],
-                                                       device_type='daplink')
+            platform_data = self.plat_db.get(device['target_id'][0:4],
+                                             device_type='daplink',
+                                             verbose_data=True)
+            device.update(platform_data or {'platform_name': None})
         else:
             device['platform_name'] = None
 
@@ -270,7 +275,10 @@ class MbedLsToolsBase(object):
             if m:
                 device['url'] = m.group(1).strip()
                 identifier = device['url'].split('/')[-1]
-                device['platform_name'] = self.plat_db.get(identifier, device_type='jlink')
+                platform_data = self.plat_db.get(identifier,
+                                                 device_type='jlink',
+                                                 verbose_data=True)
+                device.update(platform_data or {'platform_name': None})
                 break
 
 

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -110,7 +110,7 @@ class MbedLsToolsBase(object):
     def list_mbeds(
             self, fs_interaction=FSInteraction.BeforeFilter,
             filter_function=None, unique_names=False,
-            include_extra_info=False):
+            include_extra_info=False, read_details_txt=None):
         """ List details of connected devices
         @return Returns list of structures with detailed info about each mbed
         @param fs_interaction A member of the FSInteraction class that picks the
@@ -122,9 +122,16 @@ class MbedLsToolsBase(object):
           'platform_unique_name' member of the output dict
         @param include_extra_info A boolean controlling the presense of the
           output dict attributes read from other files present on the 'mount_point'
+        @param read_details_txt Deprecated alias of the parameter 'include_extra_info'
         @details Function returns list of dictionaries with mbed attributes 'mount_point', TargetID name etc.
         Function returns mbed list with platform names if possible
         """
+
+        if read_details_txt is not None:
+            logger.warning("The 'read_details_txt' parameter is deprecated for function "
+                           "'list_mbeds'. Please use the equivalent 'include_extra_info' instead.")
+            include_extra_info = read_details_txt
+
         platform_count = {}
         candidates = list(self.find_candidates())
         logger.debug("Candidates for display %r", candidates)

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -249,6 +249,9 @@ class MbedLsToolsBase(object):
             board_file_key = 'board.html'
         elif 'user guide.html' in lower_case_map:
             board_file_key = 'user guide.html'
+        else:
+            logger.warning('No valid file found to update JLink device details')
+            return
 
         board_file_path = os.path.join(device['mount_point'], lower_case_map[board_file_key])
         with open(board_file_path, 'r') as board_file:

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -94,7 +94,7 @@ def print_version(mbeds, args):
     print(get_version())
 
 def print_mbeds(mbeds, args, simple):
-    devices = mbeds.list_mbeds(unique_names=True, read_details_txt=True)
+    devices = mbeds.list_mbeds(unique_names=True, include_extra_info=True)
     if devices:
         from prettytable import PrettyTable
         columns = ['platform_name', 'platform_name_unique', 'mount_point',
@@ -134,13 +134,13 @@ def list_platforms(mbeds, args):
 
 def mbeds_as_json(mbeds, args):
     print(json.dumps(mbeds.list_mbeds(unique_names=True,
-                                      read_details_txt=True),
+                                      include_extra_info=True),
                      indent=4, sort_keys=True))
 
 def json_by_target_id(mbeds, args):
     print(json.dumps({m['target_id']: m for m
                       in mbeds.list_mbeds(unique_names=True,
-                                          read_details_txt=True)},
+                                          include_extra_info=True)},
                      indent=4, sort_keys=True))
 
 def json_platforms(mbeds, args):

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -94,7 +94,7 @@ def print_version(mbeds, args):
     print(get_version())
 
 def print_mbeds(mbeds, args, simple):
-    devices = mbeds.list_mbeds(unique_names=True, include_extra_info=True)
+    devices = mbeds.list_mbeds(unique_names=True, read_details_txt=True)
     if devices:
         from prettytable import PrettyTable
         columns = ['platform_name', 'platform_name_unique', 'mount_point',
@@ -134,13 +134,13 @@ def list_platforms(mbeds, args):
 
 def mbeds_as_json(mbeds, args):
     print(json.dumps(mbeds.list_mbeds(unique_names=True,
-                                      include_extra_info=True),
+                                      read_details_txt=True),
                      indent=4, sort_keys=True))
 
 def json_by_target_id(mbeds, args):
     print(json.dumps({m['target_id']: m for m
                       in mbeds.list_mbeds(unique_names=True,
-                                          include_extra_info=True)},
+                                          read_details_txt=True)},
                      indent=4, sort_keys=True))
 
 def json_platforms(mbeds, args):

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -43,6 +43,12 @@ LOCAL_MOCKS_DATABASE = join(user_data_dir("mbedls"), "mock.json")
 
 DEFAULT_PLATFORM_DB = {
     u'daplink': {
+        u'0001': u'LPC2368',
+        u'0002': u'LPC2368',
+        u'0003': u'LPC2368',
+        u'0004': u'LPC2368',
+        u'0005': u'LPC2368',
+        u'0006': u'LPC2368',
         u'0007': u'LPC2368',
         u'0100': u'LPC2368',
         u'0183': u'UBLOX_C027',

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -47,7 +47,13 @@ DEFAULT_PLATFORM_DB = {
     u'0003': u'LPC2368',
     u'0004': u'LPC2368',
     u'0005': u'LPC2368',
-    u'0006': u'LPC2368',
+    u'0006': {
+        u'default': 'daplink',
+        u'devices': {
+            u'daplink': u'LPC2368',
+            u'jlink': u'NRF52_DK'
+        }
+    },
     u'0007': u'LPC2368',
     u'0100': u'LPC2368',
     u'0183': u'UBLOX_C027',
@@ -341,12 +347,18 @@ class PlatformDatabase(object):
     def all_ids(self):
         return iter(self._keys)
 
-    def get(self, index, default=None):
+    def get(self, index, default=None, device_type=None):
         """Standard lookup function. Works exactly like a dict"""
         for db in self._dbs.values():
             maybe_answer = db.get(index, None)
             if maybe_answer:
-                return maybe_answer
+                if isinstance(maybe_answer, dict):
+                    if device_type is None:
+                        device_type = maybe_answer['default']
+
+                    return maybe_answer['devices'][device_type]
+                else:
+                    return maybe_answer
 
         return default
 

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -20,7 +20,7 @@ limitations under the License.
 import datetime
 import json
 import re
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from copy import copy
 from io import open
 from os import makedirs
@@ -42,239 +42,235 @@ LOCAL_PLATFORM_DATABASE = join(user_data_dir("mbedls"), "platforms.json")
 LOCAL_MOCKS_DATABASE = join(user_data_dir("mbedls"), "mock.json")
 
 DEFAULT_PLATFORM_DB = {
-    u'0001': u'LPC2368',
-    u'0002': u'LPC2368',
-    u'0003': u'LPC2368',
-    u'0004': u'LPC2368',
-    u'0005': u'LPC2368',
-    u'0006': {
-        u'default': 'daplink',
-        u'devices': {
-            u'daplink': u'LPC2368',
-            u'jlink': u'NRF52_DK'
-        }
+    u'daplink': {
+        u'0007': u'LPC2368',
+        u'0100': u'LPC2368',
+        u'0183': u'UBLOX_C027',
+        u'0200': u'KL25Z',
+        u'0201': u'KW41Z',
+        u'0210': u'KL05Z',
+        u'0214': u'HEXIWEAR',
+        u'0217': u'K82F',
+        u'0218': u'KL82Z',
+        u'0220': u'KL46Z',
+        u'0227': u'MIMXRT1050_EVK',
+        u'0230': u'K20D50M',
+        u'0231': u'K22F',
+        u'0240': u'K64F',
+        u'0245': u'K64F',
+        u'0250': u'KW24D',
+        u'0261': u'KL27Z',
+        u'0262': u'KL43Z',
+        u'0300': u'MTS_GAMBIT',
+        u'0305': u'MTS_MDOT_F405RG',
+        u'0310': u'MTS_DRAGONFLY_F411RE',
+        u'0311': u'K66F',
+        u'0315': u'MTS_MDOT_F411RE',
+        u'0350': u'XDOT_L151CC',
+        u'0400': u'MAXWSNENV',
+        u'0405': u'MAX32600MBED',
+        u'0406': u'MAX32620MBED',
+        u'0407': u'MAX32620HSP',
+        u'0408': u'MAX32625NEXPAQ',
+        u'0409': u'MAX32630FTHR',
+        u'0415': u'MAX32625MBED',
+        u'0450': u'MTB_UBLOX_ODIN_W2',
+        u'0451': u'MTB_MXCHIP_EMW3166',
+        u'0452': u'MTB_LAIRD_BL600',
+        u'0453': u'MTB_MTS_XDOT',
+        u'0454': u'MTB_MTS_DRAGONFLY',
+        u'0455': u'MTB_UBLOX_NINA_B1',
+        u'0456': u'MTB_MURATA_ABZ',
+        u'0458': u'MTB_ADV_WISE_1510',
+        u'0459': u'MTB_ADV_WISE_1530',
+        u'0460': u'MTB_ADV_WISE_1570',
+        u'0500': u'SPANSION_PLACEHOLDER',
+        u'0505': u'SPANSION_PLACEHOLDER',
+        u'0510': u'SPANSION_PLACEHOLDER',
+        u'0602': u'EV_COG_AD3029LZ',
+        u'0603': u'EV_COG_AD4050LZ',
+        u'0700': u'NUCLEO_F103RB',
+        u'0705': u'NUCLEO_F302R8',
+        u'0710': u'NUCLEO_L152RE',
+        u'0715': u'NUCLEO_L053R8',
+        u'0720': u'NUCLEO_F401RE',
+        u'0725': u'NUCLEO_F030R8',
+        u'0730': u'NUCLEO_F072RB',
+        u'0735': u'NUCLEO_F334R8',
+        u'0740': u'NUCLEO_F411RE',
+        u'0742': u'NUCLEO_F413ZH',
+        u'0743': u'DISCO_F413ZH',
+        u'0744': u'NUCLEO_F410RB',
+        u'0745': u'NUCLEO_F303RE',
+        u'0746': u'DISCO_F303VC',
+        u'0747': u'NUCLEO_F303ZE',
+        u'0750': u'NUCLEO_F091RC',
+        u'0755': u'NUCLEO_F070RB',
+        u'0760': u'NUCLEO_L073RZ',
+        u'0764': u'DISCO_L475VG_IOT01A',
+        u'0765': u'NUCLEO_L476RG',
+        u'0766': u'SILICA_SENSOR_NODE',
+        u'0770': u'NUCLEO_L432KC',
+        u'0775': u'NUCLEO_F303K8',
+        u'0777': u'NUCLEO_F446RE',
+        u'0778': u'NUCLEO_F446ZE',
+        u'0779': u'NUCLEO_L433RC_P',
+        u'0780': u'NUCLEO_L011K4',
+        u'0785': u'NUCLEO_F042K6',
+        u'0788': u'DISCO_F469NI',
+        u'0790': u'NUCLEO_L031K6',
+        u'0791': u'NUCLEO_F031K6',
+        u'0795': u'DISCO_F429ZI',
+        u'0796': u'NUCLEO_F429ZI',
+        u'0797': u'NUCLEO_F439ZI',
+        u'0799': u'ST_PLACEHOLDER',
+        u'0805': u'DISCO_L053C8',
+        u'0810': u'DISCO_F334C8',
+        u'0812': u'NUCLEO_F722ZE',
+        u'0813': u'NUCLEO_H743ZI',
+        u'0815': u'DISCO_F746NG',
+        u'0816': u'NUCLEO_F746ZG',
+        u'0817': u'DISCO_F769NI',
+        u'0818': u'NUCLEO_F767ZI',
+        u'0819': u'NUCLEO_F756ZG',
+        u'0820': u'DISCO_L476VG',
+        u'0821': u'NUCLEO_L452RE',
+        u'0822': u'DISCO_L496G',
+        u'0823': u'NUCLEO_L496ZG',
+        u'0824': u'LPC824',
+        u'0826': u'NUCLEO_F412ZG',
+        u'0827': u'NUCLEO_L486RG',
+        u'0828': u'NUCLEO_L496ZG_P',
+        u'0829': u'NUCLEO_L452RE_P',
+        u'0830': u'DISCO_F407VG',
+        u'0833': u'DISCO_L072CZ_LRWAN1',
+        u'0835': u'NUCLEO_F207ZG',
+        u'0840': u'B96B_F446VE',
+        u'0900': u'XPRO_SAMR21',
+        u'0905': u'XPRO_SAMW25',
+        u'0910': u'XPRO_SAML21',
+        u'0915': u'XPRO_SAMD21',
+        u'1000': u'LPC2368',
+        u'1001': u'LPC2368',
+        u'1010': u'LPC1768',
+        u'1017': u'HRM1017',
+        u'1018': u'SSCI824',
+        u'1019': u'TY51822R3',
+        u'1022': u'RO359B',
+        u'1034': u'LPC11U34',
+        u'1040': u'LPC11U24',
+        u'1045': u'LPC11U24',
+        u'1050': u'LPC812',
+        u'1054': u'LPC54114',
+        u'1056': u'LPC546XX',
+        u'1060': u'LPC4088',
+        u'1061': u'LPC11U35_401',
+        u'1062': u'LPC4088_DM',
+        u'1070': u'NRF51822',
+        u'1075': u'NRF51822_OTA',
+        u'1080': u'OC_MBUINO',
+        u'1090': u'RBLAB_NRF51822',
+        u'1095': u'RBLAB_BLENANO',
+        u'1100': u'NRF51_DK',
+        u'1101': u'NRF52_DK',
+        u'1102': u'NRF52840_DK',
+        u'1105': u'NRF51_DK_OTA',
+        u'1114': u'LPC1114',
+        u'1120': u'NRF51_DONGLE',
+        u'1130': u'NRF51822_SBK',
+        u'1140': u'WALLBOT_BLE',
+        u'1168': u'LPC11U68',
+        u'1200': u'NCS36510',
+        u'1234': u'UBLOX_C027',
+        u'1235': u'UBLOX_C027',
+        u'1236': u'UBLOX_EVK_ODIN_W2',
+        u'1237': u'UBLOX_EVK_NINA_B1',
+        u'1300': u'NUC472-NUTINY',
+        u'1301': u'NUMBED',
+        u'1302': u'NUMAKER_PFM_NUC472',
+        u'1303': u'NUMAKER_PFM_M453',
+        u'1304': u'NUMAKER_PFM_M487',
+        u'1305': u'NUMAKER_PFM_M2351',
+        u'1306': u'NUMAKER_PFM_NANO130',
+        u'1307': u'NUMAKER_PFM_NUC240',
+        u'1549': u'LPC1549',
+        u'1600': u'LPC4330_M4',
+        u'1605': u'LPC4330_M4',
+        u'2000': u'EFM32_G8XX_STK',
+        u'2005': u'EFM32HG_STK3400',
+        u'2010': u'EFM32WG_STK3800',
+        u'2015': u'EFM32GG_STK3700',
+        u'2020': u'EFM32LG_STK3600',
+        u'2025': u'EFM32TG_STK3300',
+        u'2030': u'EFM32ZG_STK3200',
+        u'2035': u'EFM32PG_STK3401',
+        u'2040': u'EFM32PG12_STK3402',
+        u'2041': u'TB_SENSE_12',
+        u'2045': u'TB_SENSE_1',
+        u'2100': u'XBED_LPC1768',
+        u'2201': u'WIZWIKI_W7500',
+        u'2202': u'WIZWIKI_W7500ECO',
+        u'2203': u'WIZWIKI_W7500P',
+        u'2500': u'ADV_WISE_1570',
+        u'3001': u'LPC11U24',
+        u'4000': u'LPC11U35_Y5_MBUG',
+        u'4005': u'NRF51822_Y5_MBUG',
+        u'4100': u'MOTE_L152RC',
+        u'4337': u'LPC4337',
+        u'4500': u'DELTA_DFCM_NNN40',
+        u'4501': u'DELTA_DFBM_NQ620',
+        u'4502': u'DELTA_DFCM_NNN50',
+        u'4600': u'REALTEK_RTL8195AM',
+        u'5000': u'ARM_MPS2',
+        u'5001': u'ARM_MPS2_M0',
+        u'5002': u'ARM_BEETLE_SOC',
+        u'5003': u'ARM_MPS2_M0P',
+        u'5005': u'ARM_MPS2_M0DS',
+        u'5007': u'ARM_MPS2_M1',
+        u'5009': u'ARM_MPS2_M3',
+        u'5011': u'ARM_MPS2_M4',
+        u'5015': u'ARM_MPS2_M7',
+        u'5020': u'HOME_GATEWAY_6LOWPAN',
+        u'5500': u'RZ_A1H',
+        u'5501': u'GR_LYCHEE',
+        u'6660': u'NZ32_SC151',
+        u'7010': u'BLUENINJA_CDP_TZ01B',
+        u'7011': u'TMPM066',
+        u'7013': u'TMPM46B',
+        u'7402': u'MBED_BR_HAT',
+        u'7778': u'TEENSY3_1',
+        u'8001': u'UNO_91H',
+        u'9001': u'LPC1347',
+        u'9002': u'LPC11U24',
+        u'9003': u'LPC1347',
+        u'9004': u'ARCH_PRO',
+        u'9006': u'LPC11U24',
+        u'9007': u'LPC11U35_501',
+        u'9008': u'XADOW_M0',
+        u'9009': u'ARCH_BLE',
+        u'9010': u'ARCH_GPRS',
+        u'9011': u'ARCH_MAX',
+        u'9012': u'SEEED_TINY_BLE',
+        u'9900': u'NRF51_MICROBIT',
+        u'C002': u'VK_RZ_A1H',
+        u'C005': u'MTM_MTCONNECT04S',
+        u'C006': u'VBLUNO51',
+        u'C008': u'SAKURAIO_EVB_01',
+        u'C030': u'UBLOX_C030_U201',
+        u'C031': u'UBLOX_C030_N211',
+        u'C032': u'UBLOX_C030_R404M',
+        u'C033': u'UBLOX_C030_R410M',
+        u'C034': u'UBLOX_C030_S200',
+        u'C035': u'UBLOX_C030_R3121',
+        u'FFFF': u'K20 BOOTLOADER',
+        u'RIOT': u'RIOT',
     },
-    u'0007': u'LPC2368',
-    u'0100': u'LPC2368',
-    u'0183': u'UBLOX_C027',
-    u'0200': u'KL25Z',
-    u'0201': u'KW41Z',
-    u'0210': u'KL05Z',
-    u'0214': u'HEXIWEAR',
-    u'0217': u'K82F',
-    u'0218': u'KL82Z',
-    u'0220': u'KL46Z',
-    u'0227': u'MIMXRT1050_EVK',
-    u'0230': u'K20D50M',
-    u'0231': u'K22F',
-    u'0240': u'K64F',
-    u'0245': u'K64F',
-    u'0250': u'KW24D',
-    u'0261': u'KL27Z',
-    u'0262': u'KL43Z',
-    u'0300': u'MTS_GAMBIT',
-    u'0305': u'MTS_MDOT_F405RG',
-    u'0310': u'MTS_DRAGONFLY_F411RE',
-    u'0311': u'K66F',
-    u'0315': u'MTS_MDOT_F411RE',
-    u'0350': u'XDOT_L151CC',
-    u'0400': u'MAXWSNENV',
-    u'0405': u'MAX32600MBED',
-    u'0406': u'MAX32620MBED',
-    u'0407': u'MAX32620HSP',
-    u'0408': u'MAX32625NEXPAQ',
-    u'0409': u'MAX32630FTHR',
-    u'0415': u'MAX32625MBED',
-    u'0450': u'MTB_UBLOX_ODIN_W2',
-    u'0451': u'MTB_MXCHIP_EMW3166',
-    u'0452': u'MTB_LAIRD_BL600',
-    u'0453': u'MTB_MTS_XDOT',
-    u'0454': u'MTB_MTS_DRAGONFLY',
-    u'0455': u'MTB_UBLOX_NINA_B1',
-    u'0456': u'MTB_MURATA_ABZ',
-    u'0458': u'MTB_ADV_WISE_1510',
-    u'0459': u'MTB_ADV_WISE_1530',
-    u'0460': u'MTB_ADV_WISE_1570',
-    u'0500': u'SPANSION_PLACEHOLDER',
-    u'0505': u'SPANSION_PLACEHOLDER',
-    u'0510': u'SPANSION_PLACEHOLDER',
-    u'0602': u'EV_COG_AD3029LZ',
-    u'0603': u'EV_COG_AD4050LZ',
-    u'0700': u'NUCLEO_F103RB',
-    u'0705': u'NUCLEO_F302R8',
-    u'0710': u'NUCLEO_L152RE',
-    u'0715': u'NUCLEO_L053R8',
-    u'0720': u'NUCLEO_F401RE',
-    u'0725': u'NUCLEO_F030R8',
-    u'0730': u'NUCLEO_F072RB',
-    u'0735': u'NUCLEO_F334R8',
-    u'0740': u'NUCLEO_F411RE',
-    u'0742': u'NUCLEO_F413ZH',
-    u'0743': u'DISCO_F413ZH',
-    u'0744': u'NUCLEO_F410RB',
-    u'0745': u'NUCLEO_F303RE',
-    u'0746': u'DISCO_F303VC',
-    u'0747': u'NUCLEO_F303ZE',
-    u'0750': u'NUCLEO_F091RC',
-    u'0755': u'NUCLEO_F070RB',
-    u'0760': u'NUCLEO_L073RZ',
-    u'0764': u'DISCO_L475VG_IOT01A',
-    u'0765': u'NUCLEO_L476RG',
-    u'0766': u'SILICA_SENSOR_NODE',
-    u'0770': u'NUCLEO_L432KC',
-    u'0775': u'NUCLEO_F303K8',
-    u'0777': u'NUCLEO_F446RE',
-    u'0778': u'NUCLEO_F446ZE',
-    u'0779': u'NUCLEO_L433RC_P',
-    u'0780': u'NUCLEO_L011K4',
-    u'0785': u'NUCLEO_F042K6',
-    u'0788': u'DISCO_F469NI',
-    u'0790': u'NUCLEO_L031K6',
-    u'0791': u'NUCLEO_F031K6',
-    u'0795': u'DISCO_F429ZI',
-    u'0796': u'NUCLEO_F429ZI',
-    u'0797': u'NUCLEO_F439ZI',
-    u'0799': u'ST_PLACEHOLDER',
-    u'0805': u'DISCO_L053C8',
-    u'0810': u'DISCO_F334C8',
-    u'0812': u'NUCLEO_F722ZE',
-    u'0813': u'NUCLEO_H743ZI',
-    u'0815': u'DISCO_F746NG',
-    u'0816': u'NUCLEO_F746ZG',
-    u'0817': u'DISCO_F769NI',
-    u'0818': u'NUCLEO_F767ZI',
-    u'0819': u'NUCLEO_F756ZG',
-    u'0820': u'DISCO_L476VG',
-    u'0821': u'NUCLEO_L452RE',
-    u'0822': u'DISCO_L496G',
-    u'0823': u'NUCLEO_L496ZG',
-    u'0824': u'LPC824',
-    u'0826': u'NUCLEO_F412ZG',
-    u'0827': u'NUCLEO_L486RG',
-    u'0828': u'NUCLEO_L496ZG_P',
-    u'0829': u'NUCLEO_L452RE_P',
-    u'0830': u'DISCO_F407VG',
-    u'0833': u'DISCO_L072CZ_LRWAN1',
-    u'0835': u'NUCLEO_F207ZG',
-    u'0840': u'B96B_F446VE',
-    u'0900': u'XPRO_SAMR21',
-    u'0905': u'XPRO_SAMW25',
-    u'0910': u'XPRO_SAML21',
-    u'0915': u'XPRO_SAMD21',
-    u'1000': u'LPC2368',
-    u'1001': u'LPC2368',
-    u'1010': u'LPC1768',
-    u'1017': u'HRM1017',
-    u'1018': u'SSCI824',
-    u'1019': u'TY51822R3',
-    u'1022': u'RO359B',
-    u'1034': u'LPC11U34',
-    u'1040': u'LPC11U24',
-    u'1045': u'LPC11U24',
-    u'1050': u'LPC812',
-    u'1054': u'LPC54114',
-    u'1056': u'LPC546XX',
-    u'1060': u'LPC4088',
-    u'1061': u'LPC11U35_401',
-    u'1062': u'LPC4088_DM',
-    u'1070': u'NRF51822',
-    u'1075': u'NRF51822_OTA',
-    u'1080': u'OC_MBUINO',
-    u'1090': u'RBLAB_NRF51822',
-    u'1095': u'RBLAB_BLENANO',
-    u'1100': u'NRF51_DK',
-    u'1101': u'NRF52_DK',
-    u'1102': u'NRF52840_DK',
-    u'1105': u'NRF51_DK_OTA',
-    u'1114': u'LPC1114',
-    u'1120': u'NRF51_DONGLE',
-    u'1130': u'NRF51822_SBK',
-    u'1140': u'WALLBOT_BLE',
-    u'1168': u'LPC11U68',
-    u'1200': u'NCS36510',
-    u'1234': u'UBLOX_C027',
-    u'1235': u'UBLOX_C027',
-    u'1236': u'UBLOX_EVK_ODIN_W2',
-    u'1237': u'UBLOX_EVK_NINA_B1',
-    u'1300': u'NUC472-NUTINY',
-    u'1301': u'NUMBED',
-    u'1302': u'NUMAKER_PFM_NUC472',
-    u'1303': u'NUMAKER_PFM_M453',
-    u'1304': u'NUMAKER_PFM_M487',
-    u'1305': u'NUMAKER_PFM_M2351',
-    u'1306': u'NUMAKER_PFM_NANO130',
-    u'1307': u'NUMAKER_PFM_NUC240',
-    u'1549': u'LPC1549',
-    u'1600': u'LPC4330_M4',
-    u'1605': u'LPC4330_M4',
-    u'2000': u'EFM32_G8XX_STK',
-    u'2005': u'EFM32HG_STK3400',
-    u'2010': u'EFM32WG_STK3800',
-    u'2015': u'EFM32GG_STK3700',
-    u'2020': u'EFM32LG_STK3600',
-    u'2025': u'EFM32TG_STK3300',
-    u'2030': u'EFM32ZG_STK3200',
-    u'2035': u'EFM32PG_STK3401',
-    u'2040': u'EFM32PG12_STK3402',
-    u'2041': u'TB_SENSE_12',
-    u'2045': u'TB_SENSE_1',
-    u'2100': u'XBED_LPC1768',
-    u'2201': u'WIZWIKI_W7500',
-    u'2202': u'WIZWIKI_W7500ECO',
-    u'2203': u'WIZWIKI_W7500P',
-    u'2500': u'ADV_WISE_1570',
-    u'3001': u'LPC11U24',
-    u'4000': u'LPC11U35_Y5_MBUG',
-    u'4005': u'NRF51822_Y5_MBUG',
-    u'4100': u'MOTE_L152RC',
-    u'4337': u'LPC4337',
-    u'4500': u'DELTA_DFCM_NNN40',
-    u'4501': u'DELTA_DFBM_NQ620',
-    u'4502': u'DELTA_DFCM_NNN50',
-    u'4600': u'REALTEK_RTL8195AM',
-    u'5000': u'ARM_MPS2',
-    u'5001': u'ARM_MPS2_M0',
-    u'5002': u'ARM_BEETLE_SOC',
-    u'5003': u'ARM_MPS2_M0P',
-    u'5005': u'ARM_MPS2_M0DS',
-    u'5007': u'ARM_MPS2_M1',
-    u'5009': u'ARM_MPS2_M3',
-    u'5011': u'ARM_MPS2_M4',
-    u'5015': u'ARM_MPS2_M7',
-    u'5020': u'HOME_GATEWAY_6LOWPAN',
-    u'5500': u'RZ_A1H',
-    u'5501': u'GR_LYCHEE',
-    u'6660': u'NZ32_SC151',
-    u'7010': u'BLUENINJA_CDP_TZ01B',
-    u'7011': u'TMPM066',
-    u'7013': u'TMPM46B',
-    u'7402': u'MBED_BR_HAT',
-    u'7778': u'TEENSY3_1',
-    u'8001': u'UNO_91H',
-    u'9001': u'LPC1347',
-    u'9002': u'LPC11U24',
-    u'9003': u'LPC1347',
-    u'9004': u'ARCH_PRO',
-    u'9006': u'LPC11U24',
-    u'9007': u'LPC11U35_501',
-    u'9008': u'XADOW_M0',
-    u'9009': u'ARCH_BLE',
-    u'9010': u'ARCH_GPRS',
-    u'9011': u'ARCH_MAX',
-    u'9012': u'SEEED_TINY_BLE',
-    u'9900': u'NRF51_MICROBIT',
-    u'C002': u'VK_RZ_A1H',
-    u'C005': u'MTM_MTCONNECT04S',
-    u'C006': u'VBLUNO51',
-    u'C008': u'SAKURAIO_EVB_01',
-    u'C030': u'UBLOX_C030_U201',
-    u'C031': u'UBLOX_C030_N211',
-    u'C032': u'UBLOX_C030_R404M',
-    u'C033': u'UBLOX_C030_R410M',
-    u'C034': u'UBLOX_C030_S200',
-    u'C035': u'UBLOX_C030_R3121',
-    u'FFFF': u'K20 BOOTLOADER',
-    u'RIOT': u'RIOT',
+    'jlink': {
+        u'X349858SLYN': u'NRF52_DK',
+        u'FRDM-KL25Z': u'KL25Z',
+        u'FRDM-KL27Z': u'KL27Z',
+        u'FRDM-KL43Z': u'KL43Z'
+    }
 }
 
 
@@ -283,7 +279,7 @@ def _get_modified_time(path):
         mtime = getmtime(path)
     except OSError:
         mtime = 0
-    return datetime.date.fromtimestamp(mtime)
+    return datetime.datetime.fromtimestamp(mtime)
 
 
 def _older_than_me(path):
@@ -327,38 +323,40 @@ class PlatformDatabase(object):
         if not self._prim_db and len(database_files) == 1:
             self._prim_db = database_files[0]
         self._dbs = OrderedDict()
-        self._keys = set()
+        self._keys = defaultdict(set)
         for db in database_files:
             new_db = _overwrite_or_open(db)
-            duplicates = set(self._keys).intersection(set(new_db.keys()))
-            if duplicates:
-                logger.warning(
-                    "Duplicate platform ids found: %s,"
-                    " ignoring the definitions from %s",
-                    " ".join(duplicates), db)
-            self._dbs[db] = new_db
-            self._keys = self._keys.union(new_db.keys())
+            first_value = next(iter(new_db.values()))
+            if not isinstance(first_value, dict):
+                new_db = {
+                    'daplink': new_db
+                }
+
+            for device_type in new_db:
+                duplicates = self._keys[device_type].intersection(set(new_db[device_type].keys()))
+                duplicates = set(["%s.%s" % (device_type, k) for k in duplicates])
+                if duplicates:
+                    logger.warning(
+                        "Duplicate platform ids found: %s,"
+                        " ignoring the definitions from %s",
+                        " ".join(duplicates), db)
+                self._dbs[db] = new_db
+                self._keys[device_type] = self._keys[device_type].union(new_db[device_type].keys())
 
     def items(self):
         for db in self._dbs.values():
             for entry in db.items():
                 yield entry
 
-    def all_ids(self):
-        return iter(self._keys)
+    def all_ids(self, device_type='daplink'):
+        return iter(self._keys[device_type])
 
-    def get(self, index, default=None, device_type=None):
+    def get(self, index, default=None, device_type='daplink'):
         """Standard lookup function. Works exactly like a dict"""
         for db in self._dbs.values():
-            maybe_answer = db.get(index, None)
+            maybe_answer = db[device_type].get(index, None)
             if maybe_answer:
-                if isinstance(maybe_answer, dict):
-                    if device_type is None:
-                        device_type = maybe_answer['default']
-
-                    return maybe_answer['devices'][device_type]
-                else:
-                    return maybe_answer
+                return maybe_answer
 
         return default
 
@@ -386,7 +384,7 @@ class PlatformDatabase(object):
                          "destination database is ambiguous")
             return False
 
-    def add(self, id, platform_name, permanent=False):
+    def add(self, id, platform_name, permanent=False, device_type='daplink'):
         """Add a platform to this database, optionally updating an origin
         database
         """
@@ -395,13 +393,13 @@ class PlatformDatabase(object):
                 self._dbs[self._prim_db][id] = platform_name
             else:
                 next(iter(self._dbs.values()))[id] = platform_name
-            self._keys.add(id)
+            self._keys[device_type].add(id)
             if permanent:
                 self._update_db()
         else:
             raise ValueError("Invald target id: %s" % id)
 
-    def remove(self, id, permanent=False):
+    def remove(self, id, permanent=False, device_type='daplink'):
         """Remove a platform from this database, optionally updating an origin
         database
         """
@@ -413,7 +411,7 @@ class PlatformDatabase(object):
                 logger.debug("Removing id...")
                 removed = db[id]
                 del db[id]
-                self._keys.remove(id)
+                self._keys[device_type].remove(id)
                 if permanent:
                     self._update_db()
                 return removed

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -62,11 +62,13 @@ class BasicTestCase(unittest.TestCase):
              patch("mbed_lstools.lstools_base.MbedLsToolsBase._detect_device_type") as _d_type:
             _mpr.return_value = True
             _read_htm.return_value = (u'0241BEEFDEAD', {})
-            _get.return_value = 'foo_target'
+            _get.return_value = {
+                'platform_name': 'foo_target'
+            }
             _d_type.return_value = 'daplink'
             to_check = self.base.list_mbeds()
             _read_htm.assert_called_once_with('dummy_mount_point')
-            _get.assert_called_once_with('0241', device_type='daplink')
+            _get.assert_called_once_with('0241', device_type='daplink', verbose_data=True)
         self.assertEqual(len(to_check), 1)
         self.assertEqual(to_check[0]['target_id'], "0241BEEFDEAD")
         self.assertEqual(to_check[0]['platform_name'], 'foo_target')
@@ -84,10 +86,12 @@ class BasicTestCase(unittest.TestCase):
              patch("mbed_lstools.lstools_base.MbedLsToolsBase._detect_device_type") as _d_type:
             _mpr.return_value = True
             _read_htm.side_effect = [(u'0241BEEFDEAD', {}), (None, {})]
-            _get.return_value = 'foo_target'
+            _get.return_value = {
+                'platform_name': 'foo_target'
+            }
             _d_type.return_value = 'daplink'
             to_check = self.base.list_mbeds()
-            _get.assert_called_once_with('0241', device_type='daplink')
+            _get.assert_called_once_with('0241', device_type='daplink', verbose_data=True)
         self.assertEqual(len(to_check), 2)
         self.assertEqual(to_check[0]['target_id'], "0241BEEFDEAD")
         self.assertEqual(to_check[0]['platform_name'], 'foo_target')
@@ -109,7 +113,7 @@ class BasicTestCase(unittest.TestCase):
                 _d_type.return_value = 'daplink'
                 to_check = self.base.list_mbeds()
                 _read_htm.assert_called_once_with('dummy_mount_point')
-                _get.assert_called_once_with('not_', device_type='daplink')
+                _get.assert_called_once_with('not_', device_type='daplink', verbose_data=True)
             self.assertEqual(len(to_check), 1)
             self.assertEqual(to_check[0]['target_id'], "not_in_target_db")
             self.assertEqual(to_check[0]['platform_name'], None)
@@ -401,7 +405,9 @@ class RetargetTestCase(unittest.TestCase):
              patch("mbed_lstools.lstools_base.MbedLsToolsBase._detect_device_type") as _d_type:
             _mpr.return_value = True
             _read_htm.return_value = (u'0240DEADBEEF', {})
-            _get.return_value = 'foo_target'
+            _get.return_value = {
+                'platform_name': 'foo_target'
+            }
             _d_type.return_value = 'daplink'
             to_check = self.base.list_mbeds()
         self.assertEqual(len(to_check), 1)

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -206,6 +206,16 @@ class BasicTestCase(unittest.TestCase):
             _listdir.assert_called_once_with(dummy_mount_point)
             _open.assert_called_once_with(os.path.join(dummy_mount_point, 'User Guide.html'), 'r')
 
+            _open.reset_mock()
+            _listdir.reset_mock()
+            _listdir.return_value = ['unhelpful_file.html']
+
+            device = deepcopy(base_device)
+            self.base._update_device_details_jlink(device, False)
+            self.assertEqual(device, base_device)
+            _listdir.assert_called_once_with(dummy_mount_point)
+            _open.assert_not_called()
+
     def test_fs_never(self):
         device = {
             'target_id_usb_id': '024075309420ABCE',

--- a/test/platform_database.py
+++ b/test/platform_database.py
@@ -215,7 +215,7 @@ class OverriddenPlatformDatabaseTests(unittest.TestCase):
         self.assertEqual(self.pdb.get('0123'), 'Overriding_Platform')
         self.overriding_db.seek(0)
         self.assertEqual(self.overriding_db.read(),
-                         json.dumps(dict([('0123', 'Overriding_Platform')]))
+                         json.dumps(dict([('daplink', dict([('0123', 'Overriding_Platform')]))]))
                          .encode('utf-8'))
         self.assertBaseUnchanged()
 

--- a/test/platform_database.py
+++ b/test/platform_database.py
@@ -137,6 +137,18 @@ class EmptyPlatformDatabaseTests(unittest.TestCase):
         self.assertEqual(self.pdb.get('NOTVALID', None), None)
         self.assertEqual(self.pdb.remove('NOTVALID', permanent=False), None)
 
+    def test_simplify_verbose_data(self):
+        """Test that fetching a verbose entry without verbose data correctly
+        returns just the 'platform_name'
+        """
+        platform_data = {
+            'platform_name': 'VALID',
+            'other_data': 'data'
+        }
+        self.pdb.add('1337', platform_data, permanent=False)
+        self.assertEqual(self.pdb.get('1337', verbose_data=True), platform_data)
+        self.assertEqual(self.pdb.get('1337'), platform_data['platform_name'])
+
 class OverriddenPlatformDatabaseTests(unittest.TestCase):
     """ Test that for one database overriding another
     """


### PR DESCRIPTION
This is a proposal to address #283.

One thing that needs more investigation is how to properly identify JLink devices. Currently I'm assuming that the target id is unique and corresponds with the `platform_name`, just like DAPLink. I need to check other platforms running JLink to verify this.