### PR TITLE
Add LAIRD BL652

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -90,6 +90,7 @@ DEFAULT_PLATFORM_DB = {
         u'0458': u'MTB_ADV_WISE_1510',
         u'0459': u'MTB_ADV_WISE_1530',
         u'0460': u'MTB_ADV_WISE_1570',
+        u'0461': u'MTB_LAIRD_BL652',
         u'0500': u'SPANSION_PLACEHOLDER',
         u'0505': u'SPANSION_PLACEHOLDER',
         u'0510': u'SPANSION_PLACEHOLDER',


### PR DESCRIPTION
**This PR replaces https://github.com/ARMmbed/mbed-ls/pull/307 as I couldn't resolve conflicts while rebasing.** Since it is a very simple change, I'm closing 307 and raising this new one.

0461 = board ID assigned to MTB LAIRD BL652.
PE Platform database also updated. Target doesn't have a platform page, so slug field not updated.