### PR TITLE
Add MTB_USI_BN_BM_22

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -93,6 +93,7 @@ DEFAULT_PLATFORM_DB = {
         u'0459': u'MTB_ADV_WISE_1530',
         u'0460': u'MTB_ADV_WISE_1570',
         u'0461': u'MTB_LAIRD_BL652',
+        u'0462': u'MTB_USI_WM_BN_BM_22',
         u'0500': u'SPANSION_PLACEHOLDER',
         u'0505': u'SPANSION_PLACEHOLDER',
         u'0510': u'SPANSION_PLACEHOLDER',


### PR DESCRIPTION
0462 = board ID assigned to MTB USI BN BM 22.
PE Platform database also updated. Target doesn't have a platform page yet, so slug field not updated.

@theotherjimmy @bridadan .. could you please review / merge if all OK? Thanks!