### PR TITLE
Fix unmounted traceback

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -145,7 +145,7 @@ class MbedLsToolsBase(object):
                     FSInteraction.AfterFilter: self._fs_after_id_check,
                     FSInteraction.Never: self._fs_never
                 }[fs_interaction](device, filter_function, read_details_txt)
-                if maybe_device:
+                if maybe_device and (maybe_device['mount_point'] or self.list_unmounted):
                     if unique_names:
                         name = device['platform_name']
                         platform_count.setdefault(name, -1)

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -211,14 +211,21 @@ class MbedLsToolsBase(object):
             device['device_type'] = 'unknown'
             return
 
-        directory_entries = os.listdir(device['mount_point'])
-        device['device_type'] = self._detect_device_type(directory_entries)
-        device['target_id'] = device['target_id_usb_id']
+        try:
+            directory_entries = os.listdir(device['mount_point'])
+            device['device_type'] = self._detect_device_type(directory_entries)
+            device['target_id'] = device['target_id_usb_id']
 
-        {
-            'daplink': self._update_device_details_daplink,
-            'jlink': self._update_device_details_jlink
-        }[device['device_type']](device, read_details_txt, directory_entries)
+            {
+                'daplink': self._update_device_details_daplink,
+                'jlink': self._update_device_details_jlink
+            }[device['device_type']](device, read_details_txt, directory_entries)
+        except OSError as e:
+            logger.warning(
+                'Marking device with mount point "%s" as unmounted due to the '
+                'following error: %s', device['mount_point'], e)
+            device['mount_point'] = None
+            device['device_type'] = 'unknown'
 
 
     def _detect_device_type(self, directory_entries):

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -159,6 +159,18 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(None, self.base.plat_db.get("0342"))
         self.assertEqual(None, self.base.plat_db.get("0343"))
 
+    def test_update_device_from_fs_mid_unmount(self):
+        dummy_mount = 'dummy_mount'
+        device = {
+            'mount_point': dummy_mount
+        }
+
+        with patch('os.listdir') as _listdir:
+            _listdir.side_effect = OSError
+            self.base._update_device_from_fs(device, False)
+            self.assertEqual(device['device_type'], 'unknown')
+            self.assertEqual(device['mount_point'], None)
+
     def test_update_device_from_fs_unknown(self):
         device = {}
         self.base._update_device_from_fs(device, False)

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -118,6 +118,31 @@ class BasicTestCase(unittest.TestCase):
             self.assertEqual(to_check[0]['target_id'], "not_in_target_db")
             self.assertEqual(to_check[0]['platform_name'], None)
 
+    def test_list_mbeds_unmount_mid_read(self):
+        self.base.return_value = [{'mount_point': 'dummy_mount_point',
+                                   'target_id_usb_id': u'0240DEADBEEF',
+                                   'serial_port': "dummy_serial_port"}]
+        with patch("mbed_lstools.lstools_base.MbedLsToolsBase.mount_point_ready") as _mpr,\
+             patch('os.listdir') as _listdir:
+            _mpr.return_value = True
+            _listdir.side_effect = OSError
+            to_check = self.base.list_mbeds()
+        self.assertEqual(len(to_check), 0)
+
+    def test_list_mbeds_unmount_mid_read_list_unmounted(self):
+        self.base.list_unmounted = True
+        self.base.return_value = [{'mount_point': 'dummy_mount_point',
+                                   'target_id_usb_id': u'0240DEADBEEF',
+                                   'serial_port': "dummy_serial_port"}]
+        with patch("mbed_lstools.lstools_base.MbedLsToolsBase.mount_point_ready") as _mpr,\
+             patch('os.listdir') as _listdir:
+            _mpr.return_value = True
+            _listdir.side_effect = OSError
+            to_check = self.base.list_mbeds()
+        self.assertEqual(len(to_check), 1)
+        self.assertEqual(to_check[0]['mount_point'], None)
+        self.assertEqual(to_check[0]['device_type'], 'unknown')
+
     def test_list_manufacture_ids(self):
         table_str = self.base.list_manufacture_ids()
         self.assertTrue(isinstance(table_str, basestring))


### PR DESCRIPTION
This should fix #319.

@theotherjimmy I've wrapped the whole block in a `try`/`except` since each function can access the device files. Let me know if you want to go about it a different way. I also modified `list_mbeds` a bit so devices that unmount mid-read are treated like unmounted devices.

cc @jupe 