### PR TITLE
Release version 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf8").read()
 
 setup(name='mbed-ls',
-      version='1.4.0',
+      version='1.4.1',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,


### PR DESCRIPTION
# Fixes
  - Null handler is used by default, removing the pesky "no logger installed" warnings
  - Logging is documented in the readme
  - Treat dropped devices just like unmounted devices. Prents tracebacks when reading from a device that just dropped off.
  - Correct DISCO_L496G -> DISCO_L496AG

 # New targets
  - NUCLEO_WB55RG
  - MTB_RAK811
  - MTB_USI_BN_BM_22
  - UNO_81{A|C|AM}