### PR TITLE
Fixing last unprotected registry access

### DIFF
--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -162,8 +162,16 @@ class MbedLsToolsWin7(MbedLsToolsBase):
                 logger.debug('Composite USB service "%s" not found' % usb_service)
 
         # Find all enumerated composite USB devices
-        composite_iter_vals = [self.iter_vals(k) for k in found_composite_keys]
-        for point, label, _ in itertools.chain.from_iterable(composite_iter_vals):
+        composite_iter_vals = []
+
+        for k in found_composite_keys:
+            try:
+                for v in self.iter_vals(k):
+                    composite_iter_vals.append(v)
+            except OSError:
+                logger.debug('Iterating composite USB keys ended earlier than expected')
+
+        for point, label, _ in composite_iter_vals:
             try:
                 # These keys in the registry enumerate all composite DosDevices
                 # as a value with an integer. This check ensures we ignore a few


### PR DESCRIPTION
This should fix #322.

The bug wasn't as bad as I thought. We already wrap every access to the Windows Registry with `try/except` blocks for when/if they fail. This was the one and only access to the Windows Registry that *wasn't* protected. So this PR just adds the `try/except` block.

I broke apart the `from_iterable` call to make sure we don't skip over the entire list of keys we're iterating over if an error is received in the middle of the list. This way it'll just move onto the next key. It also makes it a bit more clear what we're iterating over.

FYI @c1728p9 