### PR TITLE
Release version 1.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf8").read()
 
 setup(name='mbed-ls',
-      version='1.4.2',
+      version='1.4.3',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,


### PR DESCRIPTION
# Fixes

  * Provide default platform_name everywhere
  *  Windows detection of non composite devices (ex bootloader mode)

 # New targets

  * NUCLEO_F756ZG
  * MAX32625PICO
  * MAX32630MBED
  * MAX32620FTHR
  * MAX35103EVKIT2
  * MAX32630HSP3