### PR TITLE
Patch edge case for devices with unreadable files

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -217,7 +217,7 @@ class MbedLsToolsBase(object):
                 'daplink': self._update_device_details_daplink,
                 'jlink': self._update_device_details_jlink
             }[device['device_type']](device, read_details_txt, directory_entries)
-        except OSError as e:
+        except (OSError, IOError) as e:
             logger.warning(
                 'Marking device with mount point "%s" as unmounted due to the '
                 'following error: %s', device['mount_point'], e)
@@ -549,12 +549,8 @@ class MbedLsToolsBase(object):
     def _htm_lines(self, mount_point):
         if mount_point:
             mbed_htm_path = join(mount_point, self.MBED_HTM_NAME)
-            try:
-                with open(mbed_htm_path, 'r') as f:
-                    return f.readlines()
-            except IOError:
-                logger.debug('Failed to open file %s', mbed_htm_path)
-        return []
+            with open(mbed_htm_path, 'r') as f:
+                return f.readlines()
 
     @deprecated("This method will be removed from the public API. "
                 "Please use 'list_mbeds' instead")
@@ -583,13 +579,11 @@ class MbedLsToolsBase(object):
             USB Interfaces: MSD, CDC, HID
             Interface CRC: 0x26764ebf
         """
+
         if mount_point:
             path_to_details_txt = os.path.join(mount_point, self.DETAILS_TXT_NAME)
-            try:
-                with open(path_to_details_txt, 'r') as f:
-                    return self._parse_details(f.readlines())
-            except IOError as e:
-                logger.debug('Failed to open file %s: %s', path_to_details_txt, str(e))
+            with open(path_to_details_txt, 'r') as f:
+                return self._parse_details(f.readlines())
         return None
 
     @deprecated("This method will be removed from the public API. "

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -129,6 +129,50 @@ class BasicTestCase(unittest.TestCase):
             to_check = self.base.list_mbeds()
         self.assertEqual(len(to_check), 0)
 
+    def test_list_mbeds_read_mbed_htm_failure(self):
+        self.base.return_value = [{'mount_point': 'dummy_mount_point',
+                                   'target_id_usb_id': u'0240DEADBEEF',
+                                   'serial_port': "dummy_serial_port"}]
+        def _test(mock):
+            with patch("mbed_lstools.lstools_base.MbedLsToolsBase.mount_point_ready") as _mpr,\
+                 patch('os.listdir') as _listdir,\
+                 patch('__main__.open', mock):
+                _mpr.return_value = True
+                _listdir.return_value = ['MBED.HTM', 'DETAILS.TXT']
+                to_check = self.base.list_mbeds()
+                self.assertEqual(len(to_check), 0)
+
+        m = mock_open()
+        m.side_effect = OSError
+        _test(m)
+
+        m.reset_mock()
+        m.side_effect = IOError
+        _test(m)
+
+    def test_list_mbeds_read_details_txt_failure(self):
+        self.base.return_value = [{'mount_point': 'dummy_mount_point',
+                                   'target_id_usb_id': u'0240DEADBEEF',
+                                   'serial_port': "dummy_serial_port"}]
+        def _test(mock):
+            with patch("mbed_lstools.lstools_base.MbedLsToolsBase.mount_point_ready") as _mpr,\
+                 patch('os.listdir') as _listdir,\
+                 patch("mbed_lstools.lstools_base.MbedLsToolsBase._update_device_from_htm") as _htm,\
+                 patch('__main__.open', mock):
+                _mpr.return_value = True
+                _htm.side_effect = None
+                _listdir.return_value = ['MBED.HTM', 'DETAILS.TXT']
+                to_check = self.base.list_mbeds(read_details_txt=True)
+                self.assertEqual(len(to_check), 0)
+
+        m = mock_open()
+        m.side_effect = OSError
+        _test(m)
+
+        m.reset_mock()
+        m.side_effect = IOError
+        _test(m)
+
     def test_list_mbeds_unmount_mid_read_list_unmounted(self):
         self.base.list_unmounted = True
         self.base.return_value = [{'mount_point': 'dummy_mount_point',


### PR DESCRIPTION
If a device has a valid mount point but the files on present are not readable, the device should not be listed in the results (unless `list_unmounted` is `True`). As found by @jupe, we were handling this error farther down in the software stack than we should have, and thus the error was being masked/handled to quickly. This led to devices with unreadable files showing up in the list.

This PR adds a test case and a fix for this issue.

cc @theotherjimmy 