### PR TITLE
Platform DB: Add NRF51_DK to jlink section.

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -287,6 +287,10 @@ DEFAULT_PLATFORM_DB = {
         u'RIOT': u'RIOT',
     },
     u'jlink': {
+        u'X729475D28G': {
+            u'platform_name': u'NRF51_DK',
+            u'jlink_device_name': u'nRF51422_xxAC'
+        },
         u'X349858SLYN': {
             u'platform_name': u'NRF52_DK',
             u'jlink_device_name': u'nRF52832_xxaa'


### PR DESCRIPTION
Adds the required details to the platform db as read from a nordic semiconductor nRF51 DK  PCA10028 V1.2.2