### PR TITLE
Adding a --update command for pulling new target defintions from online

### DIFF
--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -130,6 +130,9 @@ def mock_platform(mbeds, args):
         else:
             logger.error("Could not parse mock from token: '%s'", token)
 
+def update_from_web(mbeds, args):
+    mbeds.plat_db.update_from_web()
+
 def list_platforms(mbeds, args):
     print(mbeds.list_manufacture_ids())
 
@@ -204,6 +207,9 @@ def parse_cli(to_parse):
         '-m', '--mock', metavar='ID:NAME',
         help='substitute or create a target ID to platform name mapping used'
         'when invoking mbedls in the current directory')
+    commands.add_argument(
+        '-U', '--update', action='store_true',
+        help='update the platform database from os.mbed.com')
 
     parser.add_argument(
         '--skip-retarget', dest='skip_retarget', default=False,
@@ -221,6 +227,8 @@ def parse_cli(to_parse):
     args = parser.parse_args(to_parse)
     if args.mock:
         args.command = mock_platform
+    elif args.update:
+        args.command = update_from_web
     return args
 
 def start_logging():

--- a/mbed_lstools/main.py
+++ b/mbed_lstools/main.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 
 # Make sure that any global generic setup is run
 from . import lstools_base
+from .platform_database import DEFAULT_UPDATE_URL
 
 import logging
 logger = logging.getLogger("mbedls.main")
@@ -131,7 +132,7 @@ def mock_platform(mbeds, args):
             logger.error("Could not parse mock from token: '%s'", token)
 
 def update_from_web(mbeds, args):
-    mbeds.plat_db.update_from_web()
+    return 0 if mbeds.plat_db.update_from_web(args.update_url) else 1
 
 def list_platforms(mbeds, args):
     print(mbeds.list_manufacture_ids())
@@ -208,8 +209,9 @@ def parse_cli(to_parse):
         help='substitute or create a target ID to platform name mapping used'
         'when invoking mbedls in the current directory')
     commands.add_argument(
-        '-U', '--update', action='store_true',
-        help='update the platform database from os.mbed.com')
+        '-U', '--update', nargs='?', default=False,
+        const=DEFAULT_UPDATE_URL, dest='update_url',
+        help='update the platform database from a URL (default: %s)' % (DEFAULT_UPDATE_URL))
 
     parser.add_argument(
         '--skip-retarget', dest='skip_retarget', default=False,
@@ -227,7 +229,7 @@ def parse_cli(to_parse):
     args = parser.parse_args(to_parse)
     if args.mock:
         args.command = mock_platform
-    elif args.update:
+    elif args.update_url:
         args.command = update_from_web
     return args
 

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -20,6 +20,7 @@ limitations under the License.
 import datetime
 import json
 import re
+import requests
 from collections import OrderedDict, defaultdict
 from copy import copy
 from io import open
@@ -478,3 +479,16 @@ class PlatformDatabase(object):
                     self._update_db()
 
                 return _modify_data_format(removed, verbose_data)
+
+    def update_from_web(self, url='https://os.mbed.com/api/v3/platforms/?format=json'):
+        r = requests.get(url)
+        platform_data = r.json()
+
+        web_platforms = {
+            v['productcode']: v['logicalboard']['name'].upper() for v in platform_data
+        }
+
+        for id, platform_name in web_platforms.items():
+            self.add(id, platform_name)
+
+        self._update_db()

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -42,6 +42,7 @@ del logging
 
 LOCAL_PLATFORM_DATABASE = join(user_data_dir("mbedls"), "platforms.json")
 LOCAL_MOCKS_DATABASE = join(user_data_dir("mbedls"), "mock.json")
+DEFAULT_UPDATE_URL = "https://os.mbed.com/api/v3/platforms/?format=json"
 
 DEFAULT_PLATFORM_DB = {
     u'daplink': {
@@ -480,7 +481,7 @@ class PlatformDatabase(object):
 
                 return _modify_data_format(removed, verbose_data)
 
-    def update_from_web(self, url='https://os.mbed.com/api/v3/platforms/?format=json'):
+    def update_from_web(self, url=DEFAULT_UPDATE_URL):
         """Update entries in the platform database from the API on the Mbed website.
         Returns False if an error occurs while updating. Otherwise True is returned.
         """

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -492,9 +492,11 @@ class PlatformDatabase(object):
     def update_from_web(self, url=DEFAULT_UPDATE_URL):
         """Update entries in the platform database from the API on the Mbed website.
 
-        If the update fails during the web request or JSON parsing, a
-        `RemotePlatformDataException` is raised. If the update fails during the
-        write to the filesystem, a `DatabaseUpdateException` is raised.
+        If the update fails to contact the provided url, a `ConnectionError` will
+        be raised (part of the `requests` library). If it fails during the web
+        request or JSON parsing, a `RemotePlatformDataException` is raised.
+        If it fails during the write to the filesystem, a `DatabaseUpdateException`
+        is raised.
 
         Returns dictionary of all updates that occurred in the following format:
             {

--- a/test/platform_database.py
+++ b/test/platform_database.py
@@ -24,9 +24,10 @@ import tempfile
 import json
 from mock import patch, MagicMock, DEFAULT
 from io import StringIO
+from requests.exceptions import ConnectionError
 
 from mbed_lstools.platform_database import PlatformDatabase, DEFAULT_PLATFORM_DB,\
-    LOCAL_PLATFORM_DATABASE
+    LOCAL_PLATFORM_DATABASE, RemotePlatformDataException, DatabaseUpdateException
 
 try:
     unicode
@@ -151,7 +152,6 @@ class EmptyPlatformDatabaseTests(unittest.TestCase):
 
     def test_update_from_web(self):
         with patch("requests.get") as _get:
-            self.assertEqual(self.pdb.get('1337'), None)
             _result = MagicMock()
             _result.configure_mock(**{
                 'json.return_value': [
@@ -168,6 +168,60 @@ class EmptyPlatformDatabaseTests(unittest.TestCase):
             self.pdb.update_from_web()
             _result.json.assert_called_once()
             self.assertEqual(self.pdb.get('1337'), 'DUMMY_BOARD')
+
+    def test_update_from_web_json_error(self):
+        with patch("requests.get") as _get:
+            _result = MagicMock()
+            _result.configure_mock(**{
+                'json.side_effect': ValueError
+            })
+            _get.return_value = _result
+
+            exception_raised = False
+            try:
+                self.pdb.update_from_web()
+            except RemotePlatformDataException:
+                exception_raised = True
+
+            self.assertTrue(exception_raised)
+
+    def test_update_from_web_request_error(self):
+        with patch("requests.get") as _get:
+            _get.side_effect = ConnectionError
+
+            exception_raised = False
+            try:
+                self.pdb.update_from_web()
+            except ConnectionError:
+                exception_raised = True
+
+            self.assertTrue(exception_raised)
+
+    def test_update_from_web_update_error(self):
+        with patch("requests.get") as _get,\
+             patch.object(PlatformDatabase, "_update_db") as _update_db:
+            _result = MagicMock()
+            _result.configure_mock(**{
+                'json.return_value': [
+                    {
+                        'productcode': '1337',
+                        'logicalboard': {
+                            'name': 'dummy_board'
+                        }
+                    }
+                ]
+            })
+            _get.return_value = _result
+            _update_db.return_value = False
+
+            exception_raised = False
+            try:
+                self.pdb.update_from_web()
+            except DatabaseUpdateException:
+                exception_raised = True
+
+            _update_db.assert_called_once()
+            self.assertTrue(exception_raised)
 
 class OverriddenPlatformDatabaseTests(unittest.TestCase):
     """ Test that for one database overriding another

--- a/test/platform_database.py
+++ b/test/platform_database.py
@@ -149,6 +149,26 @@ class EmptyPlatformDatabaseTests(unittest.TestCase):
         self.assertEqual(self.pdb.get('1337', verbose_data=True), platform_data)
         self.assertEqual(self.pdb.get('1337'), platform_data['platform_name'])
 
+    def test_update_from_web(self):
+        with patch("requests.get") as _get:
+            self.assertEqual(self.pdb.get('1337'), None)
+            _result = MagicMock()
+            _result.configure_mock(**{
+                'json.return_value': [
+                    {
+                        'productcode': '1337',
+                        'logicalboard': {
+                            'name': 'dummy_board'
+                        }
+                    }
+                ]
+            })
+            _get.return_value = _result
+
+            self.pdb.update_from_web()
+            _result.json.assert_called_once()
+            self.assertEqual(self.pdb.get('1337'), 'DUMMY_BOARD')
+
 class OverriddenPlatformDatabaseTests(unittest.TestCase):
     """ Test that for one database overriding another
     """


### PR DESCRIPTION
This is a very basic implementation of #119.

FYI @theotherjimmy @jupe 

**TODO**

- [x] Indicate success of update with error code
- [x] Throw exception on failed update (edit: using a return code)
- [x] Add doc string for public api
- [x] Document structure of JSON for plat_db
- [x] Add url argument for the update cli command
~~- [ ] Change the `--update` argument to a full subcommand (ex `mbedls update`)~~
        - Edit: holding off on this for a later PR
- [x] Add more log output during the update

