### PR TITLE
Moving warning about htm-based target id to debug output

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -301,7 +301,7 @@ class MbedLsToolsBase(object):
                             htm_target_id, device['target_id_usb_id'])
             device['target_id'] = htm_target_id
         else:
-            logger.warning("Could not read htm on from usb id %s. "
+            logger.debug("Could not read htm on from usb id %s. "
                             "Falling back to usb id",
                             device['target_id_usb_id'])
             device['target_id'] = device['target_id_usb_id']


### PR DESCRIPTION
This change was made due to a concern raised by @linlingao.

When testing with greentea/htrun, your console can be filled with tons of warnings:

```
WARNING:mbedls.lstools_base:Could not read htm on from usb id 0218000034544e45002300038e41003b8321000097969900. Falling back to usb id
WARNING:mbedls.lstools_base:MBED with target id '0217000032254e4500268003ab9a0028c0b1000097969900' is connected, but not mounted. Use the '-u' flag to include it in the list.
WARNING:mbedls.lstools_base:Could not read htm on from usb id 9900000031864e4500681013000000660000000097969901. Falling back to usb id
WARNING:mbedls.lstools_base:Could not read htm on from usb id 0311000033514e4500145015846c000d6cb1000097969900. Falling back to usb id
WARNING:mbedls.lstools_base:Could not read htm on from usb id 0218000034544e45002300038e41003b8321000097969900. Falling back to usb id
WARNING:mbedls.lstools_base:MBED with target id '0217000032254e4500268003ab9a0028c0b1000097969900' is connected, but not mounted. Use the '-u' flag to include it in the list.
WARNING:mbedls.lstools_base:Could not read htm on from usb id 9900000031864e4500681013000000660000000097969901. Falling back to usb id
WARNING:mbedls.lstools_base:Could not read htm on from usb id 0311000033514e4500145015846c000d6cb1000097969900. Falling back to usb id
WARNING:mbedls.lstools_base:Could not read htm on from usb id 0218000034544e45002300038e41003b8321000097969900. Falling back to usb id
```

This PR moves

```
WARNING:mbedls.lstools_base:Could not read htm on from usb id 0218000034544e45002300038e41003b8321000097969900. Falling back to usb id
```

to the DEBUG output instead of the warnings. This means you will still receive the following warnings:

```
WARNING:mbedls.lstools_base:MBED with target id '0217000032254e4500268003ab9a0028c0b1000097969900' is connected, but not mounted. Use the '-u' flag to include it in the list.
```