### PR TITLE
Change 9015 target name to WIO_BG96

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -273,7 +273,7 @@ DEFAULT_PLATFORM_DB = {
         u'9011': u'ARCH_MAX',
         u'9012': u'SEEED_TINY_BLE',
         u'9014': u'WIO_3G',
-        u'9015': u'WIO_LTE_M',
+        u'9015': u'WIO_BG96',
         u'9900': u'NRF51_MICROBIT',
         u'C002': u'VK_RZ_A1H',
         u'C005': u'MTM_MTCONNECT04S',


### PR DESCRIPTION
Change ID 9015 name from WIO_LTE_M to WIO_BG96.
This is a request from platform vender (Seeed).