### PR TITLE
Vid pid details

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ $ mbedls --json
         "mount_point": "D:",
         "platform_name": "K64F",
         "platform_name_unique": "K64F[0]",
+        "product_id": "0204",
         "serial_port": "COM18",
         "target_id": "0240000032044e4500257009997b00386781000097969900",
         "target_id_mbed_htm": "0240000032044e4500257009997b00386781000097969900",
-        "target_id_usb_id": "0240000032044e4500257009997b00386781000097969900"
+        "target_id_usb_id": "0240000032044e4500257009997b00386781000097969900",
+        "vendor_id": "0d28"
     }
 ]
 ```
@@ -288,7 +290,7 @@ If set to `'+'`, the mocked platform is enabled. If `'-'`, the mocked platform i
 
 ## Logging
 
-Mbed LS uses the Python `logging` module for all of its logging needs. Mbed LS uses the logger `"mbedls"` as its root, and all other loggers start with `"mbedls."`. Configuring the Python root logger automatically redirects all of the Mbed LS logs to the configured endpoint. When using the Python API, configure logging, such as by calling `logging.basicConfig()`. 
+Mbed LS uses the Python `logging` module for all of its logging needs. Mbed LS uses the logger `"mbedls"` as its root, and all other loggers start with `"mbedls."`. Configuring the Python root logger automatically redirects all of the Mbed LS logs to the configured endpoint. When using the Python API, configure logging, such as by calling `logging.basicConfig()`.
 
 # Testing
 

--- a/mbed_lstools/darwin.py
+++ b/mbed_lstools/darwin.py
@@ -45,13 +45,13 @@ def _find_TTY(obj):
 
 
 def _prune(current, keys):
-    """ Reduce the amount of data we have to sift through to only 
+    """ Reduce the amount of data we have to sift through to only
         include the specified keys, and children that contain the
         specified keys
     """
     pruned_current = {k: current[k] for k in keys if k in current}
     pruned_children = list(
-      filter(None, [_prune(c, keys) for c in 
+      filter(None, [_prune(c, keys) for c in
                     current.get('IORegistryEntryChildren', [])]))
     keep_current = any(k in current for k in keys) or pruned_children
     if keep_current:
@@ -63,7 +63,7 @@ def _prune(current, keys):
 
 
 def _dfs_usb_info(obj, parents):
-    """ Find all of the usb info that we can from this particular IORegistry 
+    """ Find all of the usb info that we can from this particular IORegistry
         tree with depth first search (and searching the parent stack....)
     """
     output = {}
@@ -80,10 +80,10 @@ def _dfs_usb_info(obj, parents):
             if 'USB Serial Number' in parent:
                 usb_info['serial'] = parent['USB Serial Number']
             if 'idVendor' in parent and 'idProduct' in parent:
-                usb_info['vendor_id'] = parent['idVendor']
-                usb_info['product_id'] = parent['idProduct']
+                usb_info['vendor_id'] = format(parent['idVendor'], '04x')
+                usb_info['product_id'] = format(parent['idProduct'], '04x')
             if usb_info['serial']:
-            	usb_info['tty'] = _find_TTY(parent)
+                usb_info['tty'] = _find_TTY(parent)
             if all(usb_info.values()):
                 break
         logger.debug("found usb info %r", usb_info)
@@ -111,7 +111,9 @@ class MbedLsToolsDarwin(MbedLsToolsBase):
             {
                 'mount_point': mounts[v],
                 'serial_port': volumes[v]['tty'],
-                'target_id_usb_id': volumes[v].get('serial')
+                'target_id_usb_id': volumes[v].get('serial'),
+                'vendor_id': volumes[v].get('vendor_id'),
+                'product_id': volumes[v].get('product_id')
             } for v in set(volumes.keys()) and set(mounts.keys())
             if v in mounts and v in volumes
         ]

--- a/mbed_lstools/linux.py
+++ b/mbed_lstools/linux.py
@@ -120,12 +120,12 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
         for common_device_name in common_device_names:
             sysfs_path = os.path.join(SYSFS_BLOCK_DEVICE_PATH, common_device_name)
             full_sysfs_path = os.readlink(sysfs_path)
-            path_parts = full_sysfs_path.split(os.sep)
+            path_parts = full_sysfs_path.split('/')
 
             end_index = -1
             for index, part in enumerate(path_parts):
                 if self.udp.search(part):
-                    end_index =index
+                    end_index = index
                     break
 
             if end_index == -1:

--- a/mbed_lstools/linux.py
+++ b/mbed_lstools/linux.py
@@ -26,6 +26,8 @@ logger = logging.getLogger("mbedls.lstools_linux")
 logger.addHandler(logging.NullHandler())
 del logging
 
+SYSFS_BLOCK_DEVICE_PATH = '/sys/class/block'
+
 def _readlink(link):
     content = os.readlink(link)
     if content.startswith(".."):
@@ -45,18 +47,22 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
             r'(pci|usb)-[0-9a-zA-Z_-]*_(?P<usbid>[0-9a-zA-Z]*)-.*$')
         self.mmp = re.compile(
             r'(?P<dev>(/[^/ ]*)+) on (?P<dir>(/[^/ ]*)+) ')
+        self.udp = re.compile(r'[0-9]+-[0-9]+')
 
     def find_candidates(self):
         disk_ids = self._dev_by_id('disk')
         serial_ids = self._dev_by_id('serial')
         mount_ids = dict(self._fat_mounts())
+        usb_info = self._sysfs_block_devices(disk_ids.values())
         logger.debug("Mount mapping %r", mount_ids)
 
         return [
             {
                 'mount_point' : mount_ids.get(disk_dev),
                 'serial_port' : serial_ids.get(disk_uuid),
-                'target_id_usb_id' : disk_uuid
+                'target_id_usb_id' : disk_uuid,
+                'vendor_id': usb_info[disk_dev]['vendor_id'],
+                'product_id': usb_info[disk_dev]['product_id']
             } for disk_uuid, disk_dev in disk_ids.items()
         ]
 
@@ -104,3 +110,52 @@ class MbedLsToolsLinuxGeneric(MbedLsToolsBase):
             match = self.nlp.search(dl)
             if match:
                 yield match.group("usbid"), _readlink(dl)
+
+    def _sysfs_block_devices(self, block_devices):
+        device_names = { os.path.basename(d): d  for d in block_devices }
+        sysfs_block_devices = set(os.listdir(SYSFS_BLOCK_DEVICE_PATH))
+        common_device_names = sysfs_block_devices.intersection(set(device_names.keys()))
+        result = {}
+
+        for common_device_name in common_device_names:
+            sysfs_path = os.path.join(SYSFS_BLOCK_DEVICE_PATH, common_device_name)
+            full_sysfs_path = os.readlink(sysfs_path)
+            path_parts = full_sysfs_path.split(os.sep)
+
+            end_index = -1
+            for index, part in enumerate(path_parts):
+                if self.udp.search(part):
+                    end_index =index
+                    break
+
+            if end_index == -1:
+                logger.debug('Did not find suitable usb folder for usb info: %s', full_sysfs_path)
+                continue
+
+            usb_info_rel_path = path_parts[:end_index + 1]
+            usb_info_path = os.path.join(SYSFS_BLOCK_DEVICE_PATH, os.sep.join(usb_info_rel_path))
+
+            vendor_id = 'unknown'
+            product_id = 'unknown'
+
+            vendor_id_file_paths = os.path.join(usb_info_path, 'idVendor')
+            product_id_file_paths = os.path.join(usb_info_path, 'idProduct')
+
+            try:
+                with open(vendor_id_file_paths, 'r') as vendor_file:
+                    vendor_id = vendor_file.read().strip()
+            except OSError as e:
+                logger.debug('Failed to read vendor id file %s weith error:', vendor_id_file_paths, e)
+
+            try:
+                with open(product_id_file_paths, 'r') as product_file:
+                    product_id = product_file.read().strip()
+            except OSError as e:
+                logger.debug('Failed to read product id file %s weith error:', product_id_file_paths, e)
+
+            result[device_names[common_device_name]] = {
+                'vendor_id': vendor_id,
+                'product_id': product_id
+            }
+
+        return result

--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -157,6 +157,8 @@ def _determine_valid_non_composite_devices(devices, target_id_usb_id_mount_point
                 'target_id_usb_id': target_id_usb_id,
                 'mount_point': target_id_usb_id_mount_point_map[target_id_usb_id]
             }
+
+            candidates[target_id_usb_id].update(_vid_pid_path_to_usb_info(device['vid_pid_path']))
         except KeyError:
             pass
 
@@ -179,6 +181,32 @@ def _determine_subdevice_capability(key):
     else:
         logger.debug('Unknown capabilities from the following ids: %s', compatible_ids)
         return None
+
+
+def _vid_pid_path_to_usb_info(vid_pid_path):
+    """! Provide the vendor ID and product ID of a device based on its entry in the registry
+    @return Returns {'vendor_id': '<vendor ID>', 'product': '<product ID>'}
+    @details If the vendor ID or product ID can't be determined, they will be returned
+    as 'unknown'.
+    """
+    result = {
+        'vendor_id': 'unknown',
+        'product_id': 'unknown'
+    }
+
+    for component in vid_pid_path.split('&'):
+        component_part = component.lower().split('_')
+
+        if len(component_part) != 2:
+            logger.debug('Unexpected VID/PID string structure %s', component)
+            break
+
+        if component_part[0] == 'vid':
+            result['vendor_id'] = component_part[1]
+        elif component_part[0] == 'pid':
+            result['product_id'] = component_part[1]
+
+    return result
 
 # =============================== Start Registry Functions ====================================
 
@@ -350,6 +378,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
                     if capability == 'msd':
                         candidates[entry_data['target_id_usb_id']]['mount_point'] = \
                             target_id_usb_id_mount_point_map[entry_data['target_id_usb_id']]
+                        candidates[entry_data['target_id_usb_id']].update(_vid_pid_path_to_usb_info(vid_pid_path))
                     elif capability == 'serial':
                         try:
                             device_parameters_key = winreg.OpenKey(subdevice_key,
@@ -361,6 +390,7 @@ class MbedLsToolsWin7(MbedLsToolsBase):
                         try:
                             candidates[entry_data['target_id_usb_id']]['serial_port'], _ = winreg.QueryValueEx(
                                 device_parameters_key, 'PortName')
+                            candidates[entry_data['target_id_usb_id']].update(_vid_pid_path_to_usb_info(vid_pid_path))
                         except OSError:
                             logger.debug('"PortName" value not found under serial device entry')
                             continue

--- a/test/os_darwin.py
+++ b/test/os_darwin.py
@@ -165,5 +165,7 @@ class DarwinTestCase(unittest.TestCase):
             candidates = self.darwin.find_candidates()
         self.assertIn({'mount_point': '/Volumes/DAPLINK',
                        'serial_port': '/dev/tty.usbmodem1422',
-                       'target_id_usb_id': '0240000034544e45003a00048e3800525a91000097969900'},
+                       'target_id_usb_id': '0240000034544e45003a00048e3800525a91000097969900',
+                       'vendor_id': '0d28',
+                       'product_id': '0204'},
                       candidates)

--- a/test/os_win7.py
+++ b/test/os_win7.py
@@ -381,7 +381,9 @@ class Win7TestCase(unittest.TestCase):
             expected_info = {
                 'mount_point': 'F:',
                 'serial_port': 'COM7',
-                'target_id_usb_id': u'0240000032044e4500257009997b00386781000097969900'
+                'target_id_usb_id': u'0240000032044e4500257009997b00386781000097969900',
+                'vendor_id': '0d28',
+                'product_id': '0204'
             }
 
             devices = self.lstool.find_candidates()
@@ -417,7 +419,9 @@ class Win7TestCase(unittest.TestCase):
             expected_info = {
                 'mount_point': 'F:',
                 'serial_port': None,
-                'target_id_usb_id': u'0000000032044e4500257009997b00386781000097969900'
+                'target_id_usb_id': u'0000000032044e4500257009997b00386781000097969900',
+                'vendor_id': '0d28',
+                'product_id': '0204'
             }
 
             devices = self.lstool.find_candidates()


### PR DESCRIPTION
This is part of the solution to #165. The next step would take place in the base class which would be responsible for altering the `device_type` field.

This PR implements a mechanism for each OS (Windows, Linux, and Mac) to provide the Vendor ID and Product ID of the Mbed devices present on the system. These two data items are present in the results as `vendor_id` and `product_id` respectively.

**Both the `vendor_id` and `product_id` fields should be displayed as a 4 character, lower case hex string.**

FYI @theotherjimmy @jupe 

Here is some sample output:

```
$ mbedls -j
[
    {
        "daplink_build": "Jan 11 2016 16:12:36",
        "daplink_url": "http://mbed.org/device/?code=07400221076061193824F764",
        "daplink_version": "0221",
        "device_type": "daplink",
        "directory_entries": [
            "DETAILS.TXT",
            "MBED.HTM"
        ],
        "mount_point": "/mnt/pci-0000_00_06_0-usb-0_3_1_1-scsi-0_0_0_0",
        "platform_name": "NUCLEO_F411RE",
        "platform_name_unique": "NUCLEO_F411RE[0]",
        "product_id": "374b",
        "serial_port": "/dev/ttyACM1",
        "target_id": "07400221076061193824F764",
        "target_id_mbed_htm": "07400221076061193824F764",
        "target_id_usb_id": "0671FF554856805087112815",
        "vendor_id": "0483"
    },
    {
        "daplink_auto_reset": "0",
        "daplink_automation_allowed": "1",
        "daplink_bootloader_crc": "0xb92403e6",
        "daplink_bootloader_version": "0244",
        "daplink_daplink_mode": "Interface",
        "daplink_git_sha": "0beabef8aa4b382809d79e98321ecf6a28936812",
        "daplink_hic_id": "97969900",
        "daplink_interface_crc": "0x434eddd1",
        "daplink_interface_version": "0246",
        "daplink_local_mods": "0",
        "daplink_overflow_detection": "1",
        "daplink_remount_count": "0",
        "daplink_unique_id": "0240000032044e4500257009997b00386781000097969900",
        "daplink_usb_interfaces": "MSD, CDC, HID",
        "daplink_version": "0246",
        "device_type": "daplink",
        "directory_entries": [
            "MBED.HTM",
            "DETAILS.TXT"
        ],
        "mount_point": "/mnt/pci-0000_00_06_0-usb-0_2_1_0-scsi-0_0_0_0",
        "platform_name": "K64F",
        "platform_name_unique": "K64F[0]",
        "product_id": "0204",
        "serial_port": "/dev/ttyACM0",
        "target_id": "0240000032044e4500257009997b00386781000097969900",
        "target_id_mbed_htm": "0240000032044e4500257009997b00386781000097969900",
        "target_id_usb_id": "0240000032044e4500257009997b00386781000097969900",
        "vendor_id": "0d28"
    }
]
```