### PR TITLE
VID/PID based device type detection

### DIFF
--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -223,7 +223,7 @@ class MbedLsToolsBase(object):
             {
                 'daplink': self._update_device_details_daplink,
                 'jlink': self._update_device_details_jlink
-            }[device['device_type'] or 'daplink'](device, read_details_txt, directory_entries)
+            }[device['device_type'] or 'daplink'](device, read_details_txt)
         except (OSError, IOError) as e:
             logger.warning(
                 'Marking device with mount point "%s" as unmounted due to the '
@@ -241,14 +241,13 @@ class MbedLsToolsBase(object):
         return self.VENDOR_ID_DEVICE_TYPE_MAP.get(device.get('vendor_id'))
 
 
-    def _update_device_details_daplink(self, device, read_details_txt, directory_entries):
+    def _update_device_details_daplink(self, device, read_details_txt):
         """ Updates the daplink-specific device information based on files from its 'mount_point'
             @param device Dictionary containing device information
             @param read_details_txt A boolean controlling the presense of the
               output dict attributes read from other files present on the 'mount_point'
-            @param directory_entries List of directories and files on the device
         """
-        lowercase_directory_entries = [e.lower() for e in directory_entries]
+        lowercase_directory_entries = [e.lower() for e in device['directory_entries']]
         if self.MBED_HTM_NAME.lower() in lowercase_directory_entries:
             self._update_device_from_htm(device)
         elif not read_details_txt:
@@ -277,12 +276,11 @@ class MbedLsToolsBase(object):
         else:
             device['platform_name'] = None
 
-    def _update_device_details_jlink(self, device, _, directory_entries):
+    def _update_device_details_jlink(self, device, _):
         """ Updates the jlink-specific device information based on files from its 'mount_point'
             @param device Dictionary containing device information
-            @param directory_entries List of directories and files on the device
         """
-        lower_case_map = {e.lower(): e for e in directory_entries}
+        lower_case_map = {e.lower(): e for e in device['directory_entries']}
 
         if 'board.html' in lower_case_map:
             board_file_key = 'board.html'

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -69,6 +69,12 @@ class MbedLsToolsBase(object):
     DETAILS_TXT_NAME = 'DETAILS.TXT'
     MBED_HTM_NAME = 'mbed.htm'
 
+    VENDOR_ID_DEVICE_TYPE_MAP = {
+        '0483': 'stlink',
+        '0d28': 'daplink',
+        '1366': 'jlink'
+    }
+
     def __init__(self, list_unmounted=False, **kwargs):
         """ ctor
         """
@@ -211,13 +217,13 @@ class MbedLsToolsBase(object):
         try:
             directory_entries = os.listdir(device['mount_point'])
             device['directory_entries'] = directory_entries
-            device['device_type'] = self._detect_device_type(directory_entries)
+            device['device_type'] = self._detect_device_type(device)
             device['target_id'] = device['target_id_usb_id']
 
             {
                 'daplink': self._update_device_details_daplink,
                 'jlink': self._update_device_details_jlink
-            }[device['device_type']](device, read_details_txt, directory_entries)
+            }[device['device_type'] or 'daplink'](device, read_details_txt, directory_entries)
         except (OSError, IOError) as e:
             logger.warning(
                 'Marking device with mount point "%s" as unmounted due to the '
@@ -226,13 +232,13 @@ class MbedLsToolsBase(object):
             device['device_type'] = 'unknown'
 
 
-    def _detect_device_type(self, directory_entries):
+    def _detect_device_type(self, device):
         """ Returns a string of the device type
-            @param directory_entries List of directories and files on the device
-            @return 'daplink' or 'jlink'
+            @param device Dictionary containing device information
+            @return Device type located in VENDOR_ID_DEVICE_TYPE_MAP or None if unknown
         """
 
-        return 'jlink' if 'segger.html' in [e.lower() for e in directory_entries] else 'daplink'
+        return self.VENDOR_ID_DEVICE_TYPE_MAP.get(device.get('vendor_id'))
 
 
     def _update_device_details_daplink(self, device, read_details_txt, directory_entries):

--- a/mbed_lstools/lstools_base.py
+++ b/mbed_lstools/lstools_base.py
@@ -221,7 +221,8 @@ class MbedLsToolsBase(object):
             device['target_id'] = device['target_id_usb_id']
 
             {
-                'daplink': self._update_device_details_daplink,
+                'daplink': self._update_device_details_daplink_compatible,
+                'stlink': self._update_device_details_daplink_compatible,
                 'jlink': self._update_device_details_jlink
             }[device['device_type'] or 'daplink'](device, read_details_txt)
         except (OSError, IOError) as e:
@@ -241,7 +242,7 @@ class MbedLsToolsBase(object):
         return self.VENDOR_ID_DEVICE_TYPE_MAP.get(device.get('vendor_id'))
 
 
-    def _update_device_details_daplink(self, device, read_details_txt):
+    def _update_device_details_daplink_compatible(self, device, read_details_txt):
         """ Updates the daplink-specific device information based on files from its 'mount_point'
             @param device Dictionary containing device information
             @param read_details_txt A boolean controlling the presense of the

--- a/test/mbedls_toolsbase.py
+++ b/test/mbedls_toolsbase.py
@@ -289,11 +289,20 @@ Remount count: 0
         self.assertEqual(device['device_type'], 'unknown')
 
     def test_detect_device_test(self):
-        device_type = self.base._detect_device_type(['Segger.html'])
-        self.assertEqual(device_type, 'jlink')
+        device_type = self.base._detect_device_type({
+            'vendor_id': '0483'
+        })
+        self.assertEqual(device_type, 'stlink')
 
-        device_type = self.base._detect_device_type(['MBED.HTM', 'DETAILS.TXT'])
+        device_type = self.base._detect_device_type({
+            'vendor_id': '0d28'
+        })
         self.assertEqual(device_type, 'daplink')
+
+        device_type = self.base._detect_device_type({
+            'vendor_id': '1366'
+        })
+        self.assertEqual(device_type, 'jlink')
 
     def test_update_device_details_jlink(self):
         jlink_html_contents = ('<html><head><meta http-equiv="refresh" '
@@ -307,7 +316,8 @@ Remount count: 0
 
         with patch('mbed_lstools.lstools_base.open', _open, create=True):
             device = deepcopy(base_device)
-            self.base._update_device_details_jlink(device, False, ['Board.html', 'User Guide.html'])
+            device['directory_entries'] = ['Board.html', 'User Guide.html']
+            self.base._update_device_details_jlink(device, False)
             self.assertEqual(device['url'], 'http://www.nxp.com/FRDM-KL27Z')
             self.assertEqual(device['platform_name'], 'KL27Z')
             _open.assert_called_once_with(os.path.join(dummy_mount_point, 'Board.html'), 'r')
@@ -315,7 +325,8 @@ Remount count: 0
             _open.reset_mock()
 
             device = deepcopy(base_device)
-            self.base._update_device_details_jlink(device, False, ['User Guide.html'])
+            device['directory_entries'] = ['User Guide.html']
+            self.base._update_device_details_jlink(device, False)
             self.assertEqual(device['url'], 'http://www.nxp.com/FRDM-KL27Z')
             self.assertEqual(device['platform_name'], 'KL27Z')
             _open.assert_called_once_with(os.path.join(dummy_mount_point, 'User Guide.html'), 'r')
@@ -323,8 +334,8 @@ Remount count: 0
             _open.reset_mock()
 
             device = deepcopy(base_device)
-            self.base._update_device_details_jlink(device, False, ['unhelpful_file.html'])
-            self.assertEqual(device, base_device)
+            device['directory_entries'] = ['unhelpful_file.html']
+            self.base._update_device_details_jlink(device, False)
             _open.assert_not_called()
 
     def test_fs_never(self):


### PR DESCRIPTION
This builds on #369 to solve issue #165.

In PR #299 I added device type detection. It used a strategy that made use of the files present on the device to identify which firmware was most likely running on the interface chip. This was good enough to differentiate between JLink and DAPLink based firmwares, but got a little more complicated for firmwares like ST-Link. ST-Link tends to mimic DAPLink files quite closely, so this option isn't really feasible any more.

This PR switches the strategy to instead identify device types by the Vendor ID. In this case I'm not currently using the Product ID as it does not seem necessary at this point. There also is a small chance that the Product IDs may vary a bit depending on the release of the interface firmware, so I figured I'd postpone this change until we have evidence to the contrary.

## Details to review (please 😄)
This also adds `stlink` to the list detectable firmwares. The STLink detection makes use of the `DAPLink` update logic at the moment, meaning you will see `daplink_build` and `daplink_version` in the JSON output, even though this is using stlink. I did this on purpose because this is how the information would have showed up in earlier versions. Should I also provide this info as `stlink_*`? Should I leave it how it is?

FYI @jupe @theotherjimmy  