### PR TITLE
Release Version 1.5.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf8").read()
 
 setup(name='mbed-ls',
-      version='1.5.0',
+      version='1.5.1',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,


### PR DESCRIPTION
# Fixes
  * Use dict.get() for safer look up of VID/PID
    Fixes a traceback
  * Linux vid pid detection fix
    Corrects detection with USB Hubs
  * Device type detection now with no files