### PR TITLE
Add support for XPLAINED PRO SAML21 board

### DIFF
--- a/mbed_lstools/__init__.py
+++ b/mbed_lstools/__init__.py
@@ -36,3 +36,4 @@ line tool (see below).
 
 from .main import mbedls_main
 from .main import create
+

--- a/mbed_lstools/darwin.py
+++ b/mbed_lstools/darwin.py
@@ -28,7 +28,7 @@ logger.addHandler(logging.NullHandler())
 DEBUG = logging.DEBUG
 del logging
 
-mbed_volume_name_match = re.compile(r'\b(mbed|SEGGER MSD)\b', re.I)
+mbed_volume_name_match = re.compile(r'\b(mbed|SEGGER MSD|ATMEL EDBG Media)\b', re.I)
 
 def _find_TTY(obj):
     ''' Find the first tty (AKA IODialinDevice) that we can find in the

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -324,6 +324,9 @@ DEFAULT_PLATFORM_DB = {
             u'platform_name': u'KL43Z',
             u'jlink_device_name': u'MKL43Z256xxx4'
         }
+    },
+    u'atmel': {
+        u'2241': 'SAML21J18A'
     }
 }
 

--- a/mbed_lstools/windows.py
+++ b/mbed_lstools/windows.py
@@ -38,7 +38,7 @@ else:
 
 
 MAX_COMPOSITE_DEVICE_SUBDEVICES = 5
-MBED_STORAGE_DEVICE_VENDOR_STRINGS = ['ven_mbed', 'ven_segger', 'ven_arm_v2m', 'ven_nxp']
+MBED_STORAGE_DEVICE_VENDOR_STRINGS = ['ven_mbed', 'ven_segger', 'ven_arm_v2m', 'ven_nxp', 'ven_atmel']
 
 
 def _get_values_with_numeric_keys(reg_key):


### PR DESCRIPTION
Prerequisite for landing ArmMbed/mbed-os#7276. Adding support for Atmel XPLAINED Pro development board. Atmel now uses something similar as DAPLink for programming. Note that the interface chip might need to be updated to latest version to support drag-n-drop programming (and thus mbed-ls), you're prompted to do this when opening Atmel Studio and connecting to the board the first time.

@theotherjimmy 