### PR TITLE
Add FUTURE_SEQUANA into the database.

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -264,6 +264,7 @@ DEFAULT_PLATFORM_DB = {
         u'5020': u'HOME_GATEWAY_6LOWPAN',
         u'5500': u'RZ_A1H',
         u'5501': u'GR_LYCHEE',
+        u'6000': u'FUTURE_SEQUANA',
         u'6660': u'NZ32_SC151',
         u'7010': u'BLUENINJA_CDP_TZ01B',
         u'7011': u'TMPM066',


### PR DESCRIPTION
Adding ID for FUTURE_SEQUANA t mbed OS target (Future Electronics "Sequana" board) into the database in preparation for the board release.
This ID has been assigned by ARM.
