### PR TITLE
Avoid deadlock on reading PList process output

### DIFF
--- a/test/os_darwin.py
+++ b/test/os_darwin.py
@@ -160,6 +160,7 @@ class DarwinTestCase(unittest.TestCase):
                      'ioreg': usb_tree}[command[0]],
                     to_ret.stdout)
                 to_ret.stdout.seek(0)
+                to_ret.communicate.return_value = (to_ret.stdout.getvalue(), "")
                 return to_ret
             _popen.side_effect = do_popen
             candidates = self.darwin.find_candidates()


### PR DESCRIPTION
On Mac (Darwin), we read much of the USB and MSD info from XML Plists.
These plists are parsed by python's `plistlib`. The prior implementation
would assume that the process generating the plist would complete by the
time the XML parser reached the end of it's current stream. As it turns
out, python3's XML parser violates this assumption. This change forces
the plist-generating process to complete before parsing starts. This may
be a tad slower, but it makes sure that we don't enter a state where we
have finished processing a plist, and the plist-generating process has
filled it's stdout pipe and is also blocked on mbed-ls reading its output.

Fixes #359 