### PR TITLE
Add Murata WSM BL241 MTB

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -104,6 +104,7 @@ DEFAULT_PLATFORM_DB = {
         u'0461': u'MTB_LAIRD_BL652',
         u'0462': u'MTB_USI_WM_BN_BM_22',
         u'0465': u'MTB_LAIRD_BL654',
+        u'0466': u'MTB_MURATA_WSM_BL241',
         u'0500': u'SPANSION_PLACEHOLDER',
         u'0505': u'SPANSION_PLACEHOLDER',
         u'0510': u'SPANSION_PLACEHOLDER',


### PR DESCRIPTION
0466 = board ID assigned to MTB Murata WSM BL241.
PE Platform database also updated. Target doesn't have a platform page yet, so slug field not updated.

@theotherjimmy @bridadan .. could you please review / merge if all OK? Thanks!